### PR TITLE
fix: add Frameworks rpath to fix app launch crash

### DIFF
--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -49,6 +49,9 @@ fi
 # Copy binary
 cp "$BUILD_DIR/$EXECUTABLE" "$APP_BUNDLE/Contents/MacOS/"
 
+# Fix rpath: SPM sets @loader_path but we need @loader_path/../Frameworks
+install_name_tool -add_rpath @loader_path/../Frameworks "$APP_BUNDLE/Contents/MacOS/$EXECUTABLE" 2>/dev/null || true
+
 # Copy Info.plist
 cp "$PROJECT_DIR/VibeUsage/Info.plist" "$APP_BUNDLE/Contents/"
 
@@ -83,31 +86,35 @@ echo "    Generated AppIcon.icns"
 
 # Codesign: sign all Sparkle internals inside-out, then framework, then app
 # Extract entitlements first to avoid --preserve-metadata timestamp errors
-echo "==> Codesigning with Developer ID..."
+echo "==> Codesigning..."
 SPARKLE_FW="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
-SPARKLE_BINS=(
-    "$SPARKLE_FW/Versions/B/XPCServices/Installer.xpc"
-    "$SPARKLE_FW/Versions/B/XPCServices/Downloader.xpc"
-    "$SPARKLE_FW/Versions/B/Autoupdate"
-    "$SPARKLE_FW/Versions/B/Updater.app"
-)
-for BIN in "${SPARKLE_BINS[@]}"; do
-    ENT=$(mktemp /tmp/ent.XXXXXX.plist)
-    # :- prefix outputs XML plist format (not binary DER)
-    codesign -d --entitlements :- "$BIN" > "$ENT" 2>/dev/null || true
-    if [ -s "$ENT" ] && grep -q '<key>' "$ENT" 2>/dev/null; then
-        codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
-    else
-        codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$BIN"
-    fi
-    rm -f "$ENT"
-done
-codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
-codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
-echo "    Signed with: $SIGN_IDENTITY"
 
-# Verify signature
-codesign --verify --deep --strict "$APP_BUNDLE"
+# Check if Developer ID certificate is available
+if security find-identity -v -p codesigning | grep -q "$SIGN_IDENTITY"; then
+    echo "    Using Developer ID: $SIGN_IDENTITY"
+    SPARKLE_BINS=(
+        "$SPARKLE_FW/Versions/B/XPCServices/Installer.xpc"
+        "$SPARKLE_FW/Versions/B/XPCServices/Downloader.xpc"
+        "$SPARKLE_FW/Versions/B/Autoupdate"
+        "$SPARKLE_FW/Versions/B/Updater.app"
+    )
+    for BIN in "${SPARKLE_BINS[@]}"; do
+        ENT=$(mktemp /tmp/ent.XXXXXX.plist)
+        codesign -d --entitlements :- "$BIN" > "$ENT" 2>/dev/null || true
+        if [ -s "$ENT" ] && grep -q '<key>' "$ENT" 2>/dev/null; then
+            codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
+        else
+            codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$BIN"
+        fi
+        rm -f "$ENT"
+    done
+    codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
+    codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
+    codesign --verify --deep --strict "$APP_BUNDLE"
+else
+    echo "    Developer ID not found, using ad-hoc signing (local use only)"
+    codesign --force --deep -s - "$APP_BUNDLE"
+fi
 
 if $NOTARIZE; then
     # Zip for notarization

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -112,6 +112,10 @@ if security find-identity -v -p codesigning | grep -q "$SIGN_IDENTITY"; then
     codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
     codesign --verify --deep --strict "$APP_BUNDLE"
 else
+    if $NOTARIZE; then
+        echo "    ERROR: Developer ID certificate not found. Notarization requires a valid Developer ID."
+        exit 1
+    fi
     echo "    Developer ID not found, using ad-hoc signing (local use only)"
     codesign --force --deep -s - "$APP_BUNDLE"
 fi

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -50,7 +50,15 @@ fi
 cp "$BUILD_DIR/$EXECUTABLE" "$APP_BUNDLE/Contents/MacOS/"
 
 # Fix rpath: SPM sets @loader_path but we need @loader_path/../Frameworks
-install_name_tool -add_rpath @loader_path/../Frameworks "$APP_BUNDLE/Contents/MacOS/$EXECUTABLE" 2>/dev/null || true
+RPATH="@loader_path/../Frameworks"
+if otool -l "$APP_BUNDLE/Contents/MacOS/$EXECUTABLE" 2>/dev/null | grep -q "$RPATH"; then
+    echo "    rpath $RPATH already present"
+else
+    if ! install_name_tool -add_rpath "$RPATH" "$APP_BUNDLE/Contents/MacOS/$EXECUTABLE"; then
+        echo "    ERROR: Failed to add rpath $RPATH with install_name_tool" >&2
+        exit 1
+    fi
+fi
 
 # Copy Info.plist
 cp "$PROJECT_DIR/VibeUsage/Info.plist" "$APP_BUNDLE/Contents/"
@@ -90,7 +98,7 @@ echo "==> Codesigning..."
 SPARKLE_FW="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 
 # Check if Developer ID certificate is available
-if security find-identity -v -p codesigning | grep -q "$SIGN_IDENTITY"; then
+if security find-identity -v -p codesigning | grep -Fq "$SIGN_IDENTITY"; then
     echo "    Using Developer ID: $SIGN_IDENTITY"
     SPARKLE_BINS=(
         "$SPARKLE_FW/Versions/B/XPCServices/Installer.xpc"
@@ -118,6 +126,7 @@ else
     fi
     echo "    Developer ID not found, using ad-hoc signing (local use only)"
     codesign --force --deep -s - "$APP_BUNDLE"
+    codesign --verify --deep --strict "$APP_BUNDLE"
 fi
 
 if $NOTARIZE; then


### PR DESCRIPTION
## Summary
- App 编译后无法启动，dyld 报错找不到 `Sparkle.framework`
- 根因：SPM 构建的二进制 `@rpath` 只有 `@loader_path`（即 `Contents/MacOS/`），但 `Sparkle.framework` 在 `Contents/Frameworks/` 下
- 用 `install_name_tool -add_rpath @loader_path/../Frameworks` 修复
- 附带改进：签名步骤在找不到 Developer ID 证书时自动 fallback 到 ad-hoc 签名，方便本地开发

## Test plan
- [x] `bash scripts/build-app.sh` 构建成功
- [x] `open "dist/Vibe Usage.app"` 正常启动
- [x] 无 Developer ID 证书时自动使用 ad-hoc 签名