### PR TITLE
fix: resolve nvm node path for DMG builds

### DIFF
--- a/VibeUsage/Services/RuntimeDetector.swift
+++ b/VibeUsage/Services/RuntimeDetector.swift
@@ -28,7 +28,6 @@ enum RuntimeDetector {
         let home = FileManager.default.homeDirectoryForCurrentUser.path
         paths.append(contentsOf: [
             "\(home)/.bun/bin",
-            "\(home)/.nvm/versions/node/current/bin",
             "\(home)/.volta/bin",
             "\(home)/.fnm/current/bin",
             "/usr/local/bin",
@@ -36,8 +35,76 @@ enum RuntimeDetector {
             "/opt/local/bin",
         ])
 
+        // nvm: resolve actual version directory (nvm doesn't create a "current" symlink)
+        paths.append(contentsOf: resolveNvmPaths(home: home))
+
         return paths
     }()
+
+    /// Resolve nvm node bin paths by reading ~/.nvm/alias/default or scanning versions directory.
+    private static func resolveNvmPaths(home: String) -> [String] {
+        let nvmDir = "\(home)/.nvm"
+        let versionsDir = "\(nvmDir)/versions/node"
+        let fm = FileManager.default
+
+        // 1. Try reading ~/.nvm/alias/default to find the default version
+        let aliasPath = "\(nvmDir)/alias/default"
+        if let alias = try? String(contentsOfFile: aliasPath, encoding: .utf8) {
+            let prefix = alias.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !prefix.isEmpty, let resolved = findNvmVersion(versionsDir: versionsDir, prefix: prefix, fm: fm) {
+                return ["\(versionsDir)/\(resolved)/bin"]
+            }
+        }
+
+        // 2. Fallback: pick the latest installed version (highest semver directory)
+        if let entries = try? fm.contentsOfDirectory(atPath: versionsDir) {
+            let sorted = entries
+                .filter { $0.hasPrefix("v") }
+                .sorted { compareVersions($0, $1) }
+            if let latest = sorted.last {
+                return ["\(versionsDir)/\(latest)/bin"]
+            }
+        }
+
+        return []
+    }
+
+    /// Find the best matching nvm version directory for a given prefix (e.g. "22" matches "v22.22.0").
+    private static func findNvmVersion(versionsDir: String, prefix: String, fm: FileManager) -> String? {
+        // Normalize: "22" → "v22", "v22" → "v22", "lts/jod" → try lts alias
+        var target = prefix
+        if target.hasPrefix("lts/") {
+            // Read lts alias: ~/.nvm/alias/lts/<name>
+            let ltsName = String(target.dropFirst(4))
+            let ltsAliasPath = "\(versionsDir)/../../alias/lts/\(ltsName)"
+            if let ltsVersion = try? String(contentsOfFile: ltsAliasPath, encoding: .utf8) {
+                target = ltsVersion.trimmingCharacters(in: .whitespacesAndNewlines)
+            } else {
+                return nil
+            }
+        }
+
+        let vPrefix = target.hasPrefix("v") ? target : "v\(target)"
+
+        guard let entries = try? fm.contentsOfDirectory(atPath: versionsDir) else { return nil }
+        // Find all versions matching prefix, pick highest
+        let matches = entries
+            .filter { $0.hasPrefix(vPrefix) && ($0 == vPrefix || $0.dropFirst(vPrefix.count).first == ".") }
+            .sorted { compareVersions($0, $1) }
+        return matches.last
+    }
+
+    /// Compare two version strings like "v22.11.0" and "v22.22.0" for sorting (ascending).
+    private static func compareVersions(_ a: String, _ b: String) -> Bool {
+        let partsA = a.dropFirst().split(separator: ".").compactMap { Int($0) }
+        let partsB = b.dropFirst().split(separator: ".").compactMap { Int($0) }
+        for i in 0..<max(partsA.count, partsB.count) {
+            let va = i < partsA.count ? partsA[i] : 0
+            let vb = i < partsB.count ? partsB[i] : 0
+            if va != vb { return va < vb }
+        }
+        return false
+    }
 
     /// Detect the best available JS runtime
     static func detect() -> Runtime? {


### PR DESCRIPTION
## Problem

When launching VibeUsage from a DMG-installed app (Finder/Launchd), `RuntimeDetector` fails to find Node.js installed via nvm.

**Root cause**: nvm does **not** create a `~/.nvm/versions/node/current` symlink. It relies on shell hooks (`.zshrc`/`.bashrc`) to dynamically set PATH. Since macOS apps launched from Finder don't load shell profiles, the environment PATH doesn't include nvm's node, and the hardcoded `current` fallback path doesn't exist.

## Fix

Replace the non-functional `~/.nvm/versions/node/current/bin` hardcoded path with dynamic resolution:

1. **Read `~/.nvm/alias/default`** to get the user's default version prefix (e.g. `"22"`, `"v20"`, `"lts/jod"`)
2. **Match against installed versions** in `~/.nvm/versions/node/` (e.g. `"22"` → `v22.22.0`)
3. **Fallback**: if alias is unreadable, pick the latest installed version by semver

Also handles:
- Bare major versions (`22` → `v22.x.x`)
- Full version prefixes (`v22.14` → `v22.14.0`)
- LTS aliases (`lts/jod` → reads `~/.nvm/alias/lts/jod`)

## Verified

Tested on a machine with nvm (4 versions installed, `alias/default` = `22`):
```
alias/default content: '22'
Resolved version: v22.22.0
Bin path: /Users/way/.nvm/versions/node/v22.22.0/bin
node exists: true
npx exists: true

Old approach: ~/.nvm/versions/node/current/bin
current symlink exists: false   ← this is why it was broken
```

## Test plan
- [x] Verified resolution logic against real nvm installation
- [x] Confirmed `current` symlink does not exist (nvm design)
- [x] Confirmed fallback (latest version scan) also works