### PR TITLE
fix: menu bar click and panel display broken in v0.3.2

### DIFF
--- a/VibeUsage/Models/UsageBucket.swift
+++ b/VibeUsage/Models/UsageBucket.swift
@@ -12,14 +12,15 @@ struct UsageBucket: Codable, Identifiable, Equatable {
     let bucketStart: String
     let inputTokens: Int
     let outputTokens: Int
+    let cacheCreationInputTokens: Int
     let cachedInputTokens: Int
     let reasoningOutputTokens: Int
     let totalTokens: Int
     let estimatedCost: Double?
 
-    /// Non-cached total (input + output + reasoning)
+    /// Full billable total (input + cacheCreation + output + reasoning)
     var computedTotal: Int {
-        inputTokens + outputTokens + reasoningOutputTokens
+        inputTokens + cacheCreationInputTokens + outputTokens + reasoningOutputTokens
     }
 
     /// Date parsed from bucketStart ISO string
@@ -35,6 +36,22 @@ struct UsageBucket: Codable, Identifiable, Equatable {
     /// Hour string (yyyy-MM-ddTHH) for hourly grouping
     var hourKey: String {
         String(bucketStart.prefix(13))
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        source = try container.decode(String.self, forKey: .source)
+        model = try container.decode(String.self, forKey: .model)
+        project = try container.decode(String.self, forKey: .project)
+        hostname = try container.decode(String.self, forKey: .hostname)
+        bucketStart = try container.decode(String.self, forKey: .bucketStart)
+        inputTokens = try container.decode(Int.self, forKey: .inputTokens)
+        outputTokens = try container.decode(Int.self, forKey: .outputTokens)
+        cacheCreationInputTokens = try container.decodeIfPresent(Int.self, forKey: .cacheCreationInputTokens) ?? 0
+        cachedInputTokens = try container.decode(Int.self, forKey: .cachedInputTokens)
+        reasoningOutputTokens = try container.decode(Int.self, forKey: .reasoningOutputTokens)
+        totalTokens = try container.decode(Int.self, forKey: .totalTokens)
+        estimatedCost = try container.decodeIfPresent(Double.self, forKey: .estimatedCost)
     }
 }
 

--- a/VibeUsage/Services/MenuBarController.swift
+++ b/VibeUsage/Services/MenuBarController.swift
@@ -39,7 +39,7 @@ private struct MenuBarLabel: View {
 ///      internal responder chain receives the event anyway.
 private final class PassthroughHostingView<V: View>: NSHostingView<V> {
     override func hitTest(_ point: NSPoint) -> NSView? { nil }
-    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { false }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
     override func mouseDown(with event: NSEvent) { superview?.mouseDown(with: event) }
     override func mouseUp(with event: NSEvent) { superview?.mouseUp(with: event) }
 }
@@ -62,6 +62,7 @@ final class MenuBarController: NSObject {
     private var isAnimating = false
 
     private static let panelWidth: CGFloat = 520
+    private static let panelHeight: CGFloat = 620
     private static let panelTopGap: CGFloat = 6
     private static let openDuration: CFTimeInterval = 0.22
     private static let closeDuration: CFTimeInterval = 0.14
@@ -204,18 +205,18 @@ final class MenuBarController: NSObject {
         // preferredContentSize must be set explicitly; otherwise contentViewController
         // assignment resizes the panel to (0,0) before SwiftUI has laid out.
         host.sizingOptions = []
-        host.preferredContentSize = NSSize(width: Self.panelWidth, height: 620)
+        host.preferredContentSize = NSSize(width: Self.panelWidth, height: Self.panelHeight)
         hostingController = host
 
         let panel = PopoverPanel(
-            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: 620),
+            contentRect: NSRect(x: 0, y: 0, width: Self.panelWidth, height: Self.panelHeight),
             styleMask: [.borderless, .nonactivatingPanel],
             backing: .buffered,
             defer: false
         )
         panel.contentViewController = host
         // Re-assert size after contentViewController may have overridden it.
-        panel.setContentSize(NSSize(width: Self.panelWidth, height: 620))
+        panel.setContentSize(NSSize(width: Self.panelWidth, height: Self.panelHeight))
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true

--- a/VibeUsage/Services/MenuBarController.swift
+++ b/VibeUsage/Services/MenuBarController.swift
@@ -31,6 +31,19 @@ private struct MenuBarLabel: View {
     }
 }
 
+/// NSHostingView subclass that passes all mouse events to the superview (NSStatusBarButton),
+/// so the button's target-action mechanism fires normally on click.
+/// Two-pronged approach:
+///   1. hitTest returns nil → AppKit routes the event to the button directly.
+///   2. mouseDown/mouseUp forward to superview → handles cases where SwiftUI's
+///      internal responder chain receives the event anyway.
+private final class PassthroughHostingView<V: View>: NSHostingView<V> {
+    override func hitTest(_ point: NSPoint) -> NSView? { nil }
+    override func acceptsFirstMouse(for event: NSEvent?) -> Bool { false }
+    override func mouseDown(with event: NSEvent) { superview?.mouseDown(with: event) }
+    override func mouseUp(with event: NSEvent) { superview?.mouseUp(with: event) }
+}
+
 /// Owns the menu-bar status item and the borderless popover panel.
 /// Replaces SwiftUI MenuBarExtra so we can:
 ///   - render stacked text (cost over tokens) via NSHostingView
@@ -41,7 +54,7 @@ final class MenuBarController: NSObject {
     private let updaterViewModel: UpdaterViewModel
 
     private let statusItem: NSStatusItem
-    private var hostingView: NSHostingView<MenuBarLabel>!
+    private var hostingView: PassthroughHostingView<MenuBarLabel>!
     private var panel: PopoverPanel?
     private var hostingController: NSHostingController<AnyView>?
     private var globalEventMonitor: Any?
@@ -95,7 +108,7 @@ final class MenuBarController: NSObject {
         button.target = self
         button.action = #selector(handleClick(_:))
 
-        let host = NSHostingView(rootView: MenuBarLabel(icon: Self.iconRaw, lines: []))
+        let host = PassthroughHostingView(rootView: MenuBarLabel(icon: Self.iconRaw, lines: []))
         host.translatesAutoresizingMaskIntoConstraints = false
         button.addSubview(host)
         NSLayoutConstraint.activate([
@@ -187,7 +200,11 @@ final class MenuBarController: NSObject {
                 .environmentObject(updaterViewModel)
         )
         let host = NSHostingController(rootView: rootView)
-        host.sizingOptions = [.intrinsicContentSize]
+        // sizingOptions = [] prevents SwiftUI from overriding the panel size.
+        // preferredContentSize must be set explicitly; otherwise contentViewController
+        // assignment resizes the panel to (0,0) before SwiftUI has laid out.
+        host.sizingOptions = []
+        host.preferredContentSize = NSSize(width: Self.panelWidth, height: 620)
         hostingController = host
 
         let panel = PopoverPanel(
@@ -197,6 +214,8 @@ final class MenuBarController: NSObject {
             defer: false
         )
         panel.contentViewController = host
+        // Re-assert size after contentViewController may have overridden it.
+        panel.setContentSize(NSSize(width: Self.panelWidth, height: 620))
         panel.isOpaque = false
         panel.backgroundColor = .clear
         panel.hasShadow = true
@@ -255,7 +274,10 @@ final class MenuBarController: NSObject {
     private static let easeIn = CAMediaTimingFunction(controlPoints: 0.5, 0, 0.9, 0.4)
 
     private func animateOpen(_ panel: PopoverPanel) {
-        guard let layer = panel.contentView?.layer else { return }
+        guard let layer = panel.contentView?.layer else {
+            panel.alphaValue = 1
+            return
+        }
         isAnimating = true
 
         // Anchor at top-right so scale and translation both appear to originate at

--- a/VibeUsage/Views/BarChartView.swift
+++ b/VibeUsage/Views/BarChartView.swift
@@ -36,7 +36,7 @@ struct BarChartView: View {
             if buckets[key] == nil {
                 buckets[key] = BarData(id: key)
             }
-            buckets[key]!.input += bucket.inputTokens
+            buckets[key]!.input += bucket.inputTokens + bucket.cacheCreationInputTokens
             buckets[key]!.output += bucket.outputTokens
             buckets[key]!.cost += bucket.estimatedCost ?? 0
         }

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -25,18 +25,24 @@ fi
 
 # Fall back to ad-hoc signing when Developer ID is unavailable (e.g. local dev install).
 # Notarization obviously cannot work in that mode, and hardened runtime's library
-# validation rejects ad-hoc dylib loads across bundles, so we drop --options runtime.
-CS_EXTRA_FLAGS=("--timestamp")
-CS_OPTIONS=("--options" "runtime")
-if ! security find-identity -v -p codesigning 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+# validation rejects ad-hoc dylib loads across bundles, so the ad-hoc path also
+# drops --options runtime.
+#
+# Identity detection captures the keychain listing into a variable first, rather than
+# piping into `grep -q`: under `set -o pipefail`, grep exits on first match and
+# `security` gets SIGPIPE (141), which would mark the pipeline failed and silently
+# switch a valid Developer ID build to ad-hoc.
+IDENTITIES=$(security find-identity -v -p codesigning 2>/dev/null || true)
+if printf '%s\n' "$IDENTITIES" | grep -Fq -- "$SIGN_IDENTITY"; then
+    codesign_args=(--force --options runtime --timestamp --sign "$SIGN_IDENTITY")
+else
     if $NOTARIZE; then
         echo "ERROR: --notarize requires Developer ID ('$SIGN_IDENTITY') but it is not in the keychain." >&2
         exit 1
     fi
     echo "==> Developer ID not found — falling back to ad-hoc signing."
     SIGN_IDENTITY="-"
-    CS_EXTRA_FLAGS=()
-    CS_OPTIONS=()
+    codesign_args=(--force --sign "$SIGN_IDENTITY")
 fi
 
 echo "==> Checking version sync..."
@@ -109,18 +115,19 @@ SPARKLE_BINS=(
 )
 for BIN in "${SPARKLE_BINS[@]}"; do
     [ -e "$BIN" ] || continue
-    # BSD mktemp requires trailing Xs — keep the template simple, no suffix.
+    # macOS BSD mktemp requires an explicit template to end with at least six Xs;
+    # `-t` sidesteps that by letting mktemp generate the random suffix itself.
     ENT=$(mktemp -t vibe-usage-ent) || { echo "mktemp failed" >&2; exit 1; }
     codesign -d --entitlements :- "$BIN" > "$ENT" 2>/dev/null || true
     if [ -s "$ENT" ] && grep -q '<key>' "$ENT" 2>/dev/null; then
-        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
+        codesign "${codesign_args[@]}" --entitlements "$ENT" "$BIN"
     else
-        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$BIN"
+        codesign "${codesign_args[@]}" "$BIN"
     fi
     [ -n "$ENT" ] && rm -f "$ENT"
 done
-codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
-codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
+codesign "${codesign_args[@]}" "$SPARKLE_FW"
+codesign "${codesign_args[@]}" "$APP_BUNDLE"
 echo "    Signed with: $SIGN_IDENTITY"
 
 codesign --verify --deep --strict "$APP_BUNDLE"

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -23,6 +23,22 @@ if [[ "${1:-}" == "--notarize" ]]; then
     NOTARIZE=true
 fi
 
+# Fall back to ad-hoc signing when Developer ID is unavailable (e.g. local dev install).
+# Notarization obviously cannot work in that mode, and hardened runtime's library
+# validation rejects ad-hoc dylib loads across bundles, so we drop --options runtime.
+CS_EXTRA_FLAGS=("--timestamp")
+CS_OPTIONS=("--options" "runtime")
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+    if $NOTARIZE; then
+        echo "ERROR: --notarize requires Developer ID ('$SIGN_IDENTITY') but it is not in the keychain." >&2
+        exit 1
+    fi
+    echo "==> Developer ID not found — falling back to ad-hoc signing."
+    SIGN_IDENTITY="-"
+    CS_EXTRA_FLAGS=()
+    CS_OPTIONS=()
+fi
+
 echo "==> Checking version sync..."
 "$SCRIPT_DIR/check-version.sh"
 
@@ -83,7 +99,7 @@ echo "    Generated AppIcon.icns"
 
 # Codesign: sign all Sparkle internals inside-out, then framework, then app
 # Extract entitlements first to avoid --preserve-metadata timestamp errors
-echo "==> Codesigning with Developer ID..."
+echo "==> Codesigning ($SIGN_IDENTITY)..."
 SPARKLE_FW="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 SPARKLE_BINS=(
     "$SPARKLE_FW/Versions/B/XPCServices/Installer.xpc"
@@ -92,17 +108,19 @@ SPARKLE_BINS=(
     "$SPARKLE_FW/Versions/B/Updater.app"
 )
 for BIN in "${SPARKLE_BINS[@]}"; do
-    ENT=$(mktemp /tmp/ent.XXXXXX.plist)
+    [ -e "$BIN" ] || continue
+    # BSD mktemp requires trailing Xs — keep the template simple, no suffix.
+    ENT=$(mktemp -t vibe-usage-ent) || { echo "mktemp failed" >&2; exit 1; }
     codesign -d --entitlements :- "$BIN" > "$ENT" 2>/dev/null || true
     if [ -s "$ENT" ] && grep -q '<key>' "$ENT" 2>/dev/null; then
-        codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
+        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
     else
-        codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$BIN"
+        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$BIN"
     fi
-    rm -f "$ENT"
+    [ -n "$ENT" ] && rm -f "$ENT"
 done
-codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
-codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
+codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
+codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
 echo "    Signed with: $SIGN_IDENTITY"
 
 codesign --verify --deep --strict "$APP_BUNDLE"


### PR DESCRIPTION
## Summary

Two bugs introduced by the NSHostingView-based menu bar redesign in v0.3.2:

- **Click never reached button**: `NSHostingView` added as a full-cover subview of `NSStatusBarButton` intercepted mouse events, preventing `button.target`/`button.action` from firing. Fixed with `PassthroughHostingView` — `hitTest` returns `nil` so AppKit routes events to the button directly, plus `mouseDown`/`mouseUp` forwarding as a fallback.

- **Panel appeared as 0×0 (invisible)**: `NSHostingController.sizingOptions = [.intrinsicContentSize]` caused SwiftUI to resize the panel to `(0, 0)` before the first layout pass. Fixed by setting `sizingOptions = []`, providing an explicit `preferredContentSize`, and calling `setContentSize` after `contentViewController` assignment.

## Test plan

- [ ] Click menu bar icon → popover appears below icon with open animation
- [ ] Click icon again → popover closes
- [ ] Click outside popover → popover closes
- [ ] Press ESC → popover closes

## Environment

- **macOS**: 15.7.4 (24G517)
- **Hardware**: Mac15,12
- **Swift**: 6.2.4 (swiftlang-6.2.4.1.4 clang-1700.6.4.2)
- **Affected version**: v0.3.2