### PR TITLE
fix: include cache_creation_input_tokens in token accounting

### DIFF
--- a/VibeUsage/Models/UsageBucket.swift
+++ b/VibeUsage/Models/UsageBucket.swift
@@ -12,14 +12,15 @@ struct UsageBucket: Codable, Identifiable, Equatable {
     let bucketStart: String
     let inputTokens: Int
     let outputTokens: Int
+    let cacheCreationInputTokens: Int
     let cachedInputTokens: Int
     let reasoningOutputTokens: Int
     let totalTokens: Int
     let estimatedCost: Double?
 
-    /// Non-cached total (input + output + reasoning)
+    /// Full billable total (input + cacheCreation + output + reasoning)
     var computedTotal: Int {
-        inputTokens + outputTokens + reasoningOutputTokens
+        inputTokens + cacheCreationInputTokens + outputTokens + reasoningOutputTokens
     }
 
     /// Date parsed from bucketStart ISO string
@@ -35,6 +36,22 @@ struct UsageBucket: Codable, Identifiable, Equatable {
     /// Hour string (yyyy-MM-ddTHH) for hourly grouping
     var hourKey: String {
         String(bucketStart.prefix(13))
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        source = try container.decode(String.self, forKey: .source)
+        model = try container.decode(String.self, forKey: .model)
+        project = try container.decode(String.self, forKey: .project)
+        hostname = try container.decode(String.self, forKey: .hostname)
+        bucketStart = try container.decode(String.self, forKey: .bucketStart)
+        inputTokens = try container.decode(Int.self, forKey: .inputTokens)
+        outputTokens = try container.decode(Int.self, forKey: .outputTokens)
+        cacheCreationInputTokens = try container.decodeIfPresent(Int.self, forKey: .cacheCreationInputTokens) ?? 0
+        cachedInputTokens = try container.decode(Int.self, forKey: .cachedInputTokens)
+        reasoningOutputTokens = try container.decode(Int.self, forKey: .reasoningOutputTokens)
+        totalTokens = try container.decode(Int.self, forKey: .totalTokens)
+        estimatedCost = try container.decodeIfPresent(Double.self, forKey: .estimatedCost)
     }
 }
 

--- a/VibeUsage/Views/BarChartView.swift
+++ b/VibeUsage/Views/BarChartView.swift
@@ -36,7 +36,7 @@ struct BarChartView: View {
             if buckets[key] == nil {
                 buckets[key] = BarData(id: key)
             }
-            buckets[key]!.input += bucket.inputTokens
+            buckets[key]!.input += bucket.inputTokens + bucket.cacheCreationInputTokens
             buckets[key]!.output += bucket.outputTokens
             buckets[key]!.cost += bucket.estimatedCost ?? 0
         }


### PR DESCRIPTION
## Problem

Claude Code heavily uses prompt caching. When `cache_creation_input_tokens` are present in the API response, they were not being recorded in `UsageBucket`, causing token counts and cost estimates to be severely underestimated — typically **50x–500x** depending on model and session length.

### Why this matters

The Anthropic API returns three token types in `usage`:
| Field | Billing rate |
|---|---|
| `input_tokens` | Full price |
| `cache_creation_input_tokens` | **Full price** (same as input) |
| `cache_read_input_tokens` | ~10% of input price |

Claude Code writes the entire conversation context to prompt cache on nearly every turn. This means `cache_creation_input_tokens` often dwarfs `input_tokens` by 10–100x, yet it was completely missing from the displayed totals.

### Real-world impact (measured on a local installation)

| Model | Previously shown | Actual tokens | Underestimate |
|---|---|---|---|
| claude-sonnet-4-6 | 2.99M | 487M | **163x** |
| claude-opus-4-6 | 1.56M | 321M | **206x** |
| claude-opus-4-7 | 20K | 10.6M | **521x** |

## Changes

- **`UsageBucket.swift`**: Add `cacheCreationInputTokens` field with a custom `init(from:)` decoder that defaults to `0` if the API doesn't yet send it (fully backward-compatible). Update `computedTotal` to include cache creation tokens.
- **`BarChartView.swift`**: Include `cacheCreationInputTokens` in the bar chart input token sum.

## Note

This PR fixes the **client-side** display layer. A companion fix is also needed in the `@vibe-cafe/vibe-usage` daemon package (`src/parsers/claude-code.js`) to actually upload `cacheCreationInputTokens` to the server. This client change is backward-compatible and will automatically show correct numbers once the daemon is updated.