### PR TITLE
fix: ad-hoc signing fallback and BSD mktemp in build-app.sh

### DIFF
--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -25,18 +25,24 @@ fi
 
 # Fall back to ad-hoc signing when Developer ID is unavailable (e.g. local dev install).
 # Notarization obviously cannot work in that mode, and hardened runtime's library
-# validation rejects ad-hoc dylib loads across bundles, so we drop --options runtime.
-CS_EXTRA_FLAGS=("--timestamp")
-CS_OPTIONS=("--options" "runtime")
-if ! security find-identity -v -p codesigning 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+# validation rejects ad-hoc dylib loads across bundles, so the ad-hoc path also
+# drops --options runtime.
+#
+# Identity detection captures the keychain listing into a variable first, rather than
+# piping into `grep -q`: under `set -o pipefail`, grep exits on first match and
+# `security` gets SIGPIPE (141), which would mark the pipeline failed and silently
+# switch a valid Developer ID build to ad-hoc.
+IDENTITIES=$(security find-identity -v -p codesigning 2>/dev/null || true)
+if printf '%s\n' "$IDENTITIES" | grep -Fq -- "$SIGN_IDENTITY"; then
+    codesign_args=(--force --options runtime --timestamp --sign "$SIGN_IDENTITY")
+else
     if $NOTARIZE; then
         echo "ERROR: --notarize requires Developer ID ('$SIGN_IDENTITY') but it is not in the keychain." >&2
         exit 1
     fi
     echo "==> Developer ID not found — falling back to ad-hoc signing."
     SIGN_IDENTITY="-"
-    CS_EXTRA_FLAGS=()
-    CS_OPTIONS=()
+    codesign_args=(--force --sign "$SIGN_IDENTITY")
 fi
 
 echo "==> Checking version sync..."
@@ -109,18 +115,19 @@ SPARKLE_BINS=(
 )
 for BIN in "${SPARKLE_BINS[@]}"; do
     [ -e "$BIN" ] || continue
-    # BSD mktemp requires trailing Xs — keep the template simple, no suffix.
+    # macOS BSD mktemp requires an explicit template to end with at least six Xs;
+    # `-t` sidesteps that by letting mktemp generate the random suffix itself.
     ENT=$(mktemp -t vibe-usage-ent) || { echo "mktemp failed" >&2; exit 1; }
     codesign -d --entitlements :- "$BIN" > "$ENT" 2>/dev/null || true
     if [ -s "$ENT" ] && grep -q '<key>' "$ENT" 2>/dev/null; then
-        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
+        codesign "${codesign_args[@]}" --entitlements "$ENT" "$BIN"
     else
-        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$BIN"
+        codesign "${codesign_args[@]}" "$BIN"
     fi
     [ -n "$ENT" ] && rm -f "$ENT"
 done
-codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
-codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
+codesign "${codesign_args[@]}" "$SPARKLE_FW"
+codesign "${codesign_args[@]}" "$APP_BUNDLE"
 echo "    Signed with: $SIGN_IDENTITY"
 
 codesign --verify --deep --strict "$APP_BUNDLE"

--- a/scripts/build-app.sh
+++ b/scripts/build-app.sh
@@ -23,6 +23,22 @@ if [[ "${1:-}" == "--notarize" ]]; then
     NOTARIZE=true
 fi
 
+# Fall back to ad-hoc signing when Developer ID is unavailable (e.g. local dev install).
+# Notarization obviously cannot work in that mode, and hardened runtime's library
+# validation rejects ad-hoc dylib loads across bundles, so we drop --options runtime.
+CS_EXTRA_FLAGS=("--timestamp")
+CS_OPTIONS=("--options" "runtime")
+if ! security find-identity -v -p codesigning 2>/dev/null | grep -q "$SIGN_IDENTITY"; then
+    if $NOTARIZE; then
+        echo "ERROR: --notarize requires Developer ID ('$SIGN_IDENTITY') but it is not in the keychain." >&2
+        exit 1
+    fi
+    echo "==> Developer ID not found — falling back to ad-hoc signing."
+    SIGN_IDENTITY="-"
+    CS_EXTRA_FLAGS=()
+    CS_OPTIONS=()
+fi
+
 echo "==> Checking version sync..."
 "$SCRIPT_DIR/check-version.sh"
 
@@ -83,7 +99,7 @@ echo "    Generated AppIcon.icns"
 
 # Codesign: sign all Sparkle internals inside-out, then framework, then app
 # Extract entitlements first to avoid --preserve-metadata timestamp errors
-echo "==> Codesigning with Developer ID..."
+echo "==> Codesigning ($SIGN_IDENTITY)..."
 SPARKLE_FW="$APP_BUNDLE/Contents/Frameworks/Sparkle.framework"
 SPARKLE_BINS=(
     "$SPARKLE_FW/Versions/B/XPCServices/Installer.xpc"
@@ -92,17 +108,19 @@ SPARKLE_BINS=(
     "$SPARKLE_FW/Versions/B/Updater.app"
 )
 for BIN in "${SPARKLE_BINS[@]}"; do
-    ENT=$(mktemp /tmp/ent.XXXXXX.plist)
+    [ -e "$BIN" ] || continue
+    # BSD mktemp requires trailing Xs — keep the template simple, no suffix.
+    ENT=$(mktemp -t vibe-usage-ent) || { echo "mktemp failed" >&2; exit 1; }
     codesign -d --entitlements :- "$BIN" > "$ENT" 2>/dev/null || true
     if [ -s "$ENT" ] && grep -q '<key>' "$ENT" 2>/dev/null; then
-        codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
+        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" --entitlements "$ENT" "$BIN"
     else
-        codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$BIN"
+        codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$BIN"
     fi
-    rm -f "$ENT"
+    [ -n "$ENT" ] && rm -f "$ENT"
 done
-codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
-codesign --force --options runtime --timestamp --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
+codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$SPARKLE_FW"
+codesign --force ${CS_OPTIONS[@]+"${CS_OPTIONS[@]}"} ${CS_EXTRA_FLAGS[@]+"${CS_EXTRA_FLAGS[@]}"} --sign "$SIGN_IDENTITY" "$APP_BUNDLE"
 echo "    Signed with: $SIGN_IDENTITY"
 
 codesign --verify --deep --strict "$APP_BUNDLE"


### PR DESCRIPTION
## Summary

Three issues in `scripts/build-app.sh` that surface when running locally without the project's Developer ID certificate:

- **Invalid BSD `mktemp` template.** `mktemp /tmp/ent.XXXXXX.plist` has X's in the middle of the path, not at the end — macOS BSD `mktemp` can't substitute and errors with "File exists" (on the literal template name). The script then runs `rm -f "$ENT"` with an empty `$ENT`, which is a silent no-op, so the bug stayed latent until something actually cared (I swapped `rm` for `trash` locally via a hook and it treated the empty arg as the cwd — took out the repo). Switched to `mktemp -t vibe-usage-ent` with a hard failure on miss, and guarded the cleanup with `[ -n "$ENT" ]`.
- **Hardcoded Developer ID identity.** The script exits at `codesign` on any machine that doesn't have `Developer ID Application: Yin Ming (D33463FWDZ)` in the keychain. Added a detection step that falls back to ad-hoc (`-`) signing for local installs; `--notarize` still requires the real cert.
- **Hardened runtime + ad-hoc don't mix across bundles.** With `--options runtime`, dyld rejects the bundled Sparkle framework at launch ("mapping process and mapped file have different Team IDs") because both sides are ad-hoc (no team). The ad-hoc path now drops `--options runtime`; Developer ID builds keep it.

Also skips missing Sparkle binaries (`[ -e "$BIN" ] || continue`) — newer Sparkle versions don't ship `Downloader.xpc` / `Autoupdate` / `Updater.app` at the hardcoded paths, so the loop currently errors on them.

## Test plan
- [x] `bash scripts/build-app.sh` on a machine with only `Apple Development` identity: builds, ad-hoc signs, launches cleanly from `/Applications` (Sparkle framework loads).
- [ ] `bash scripts/build-app.sh` on a machine with the Developer ID cert: signs with the real identity and behaves identically to before this change.
- [ ] `bash scripts/build-app.sh --notarize` without the Developer ID cert exits with a clear error instead of half-building.