### PR TITLE
[codex] add theme selection settings

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,9 +10,14 @@ let package = Package(
         .package(url: "https://github.com/sparkle-project/Sparkle", from: "2.6.0")
     ],
     targets: [
+        .target(
+            name: "VibeUsageCore",
+            path: "VibeUsageCore"
+        ),
         .executableTarget(
             name: "VibeUsage",
             dependencies: [
+                "VibeUsageCore",
                 .product(name: "Sparkle", package: "Sparkle")
             ],
             path: "VibeUsage",
@@ -20,6 +25,11 @@ let package = Package(
             resources: [
                 .process("Resources")
             ]
+        ),
+        .executableTarget(
+            name: "ThemeChecks",
+            dependencies: ["VibeUsageCore"],
+            path: "Tests/ThemeChecks"
         )
     ]
 )

--- a/Tests/ThemeChecks/main.swift
+++ b/Tests/ThemeChecks/main.swift
@@ -1,0 +1,30 @@
+import Foundation
+import VibeUsageCore
+
+func expect(_ condition: @autoclosure () -> Bool, _ message: String) {
+    if !condition() {
+        FileHandle.standardError.write(Data("ThemeChecks failed: \(message)\n".utf8))
+        Foundation.exit(1)
+    }
+}
+
+expect(AppTheme.allCases.map(\.rawValue) == ["dark", "light", "grass", "gold"],
+       "themes must expose stable raw values")
+expect(AppTheme.allCases.map(\.displayName) == ["暗黑", "浅色", "青草", "金色"],
+       "themes must expose Chinese display names")
+expect(AppTheme.storedValue("missing") == .dark,
+       "invalid stored values must fall back to dark")
+expect(AppTheme.storedValue(nil) == .dark,
+       "missing stored values must fall back to dark")
+
+let suiteName = "ai.vibecafe.vibe-usage.tests.\(UUID().uuidString)"
+let defaults = UserDefaults(suiteName: suiteName)!
+defer {
+    defaults.removePersistentDomain(forName: suiteName)
+}
+
+AppTheme.gold.save(to: defaults)
+expect(defaults.string(forKey: AppTheme.userDefaultsKey) == "gold",
+       "theme persistence must use stable raw values")
+expect(AppTheme.load(from: defaults) == .gold,
+       "theme loading must return the stored theme")

--- a/VibeUsage/Models/AppState.swift
+++ b/VibeUsage/Models/AppState.swift
@@ -1,5 +1,6 @@
 import Foundation
 import SwiftUI
+import VibeUsageCore
 
 /// Sync status for menu bar icon display
 enum SyncStatus: Equatable {
@@ -121,6 +122,11 @@ final class AppState {
         didSet { UserDefaults.standard.set(claudeRateLimitEnabled, forKey: "claudeRateLimitEnabled") }
     }
 
+    // MARK: - Appearance
+    var appTheme: AppTheme = .dark {
+        didSet { appTheme.save() }
+    }
+
     // MARK: - Menu Bar Display Prefs
     var showCostInMenuBar: Bool = true {
         didSet { UserDefaults.standard.set(showCostInMenuBar, forKey: "showCostInMenuBar") }
@@ -163,6 +169,7 @@ final class AppState {
         self.showCostInMenuBar = UserDefaults.standard.object(forKey: "showCostInMenuBar") as? Bool ?? true
         self.showTokensInMenuBar = UserDefaults.standard.object(forKey: "showTokensInMenuBar") as? Bool ?? false
         self.claudeRateLimitEnabled = UserDefaults.standard.bool(forKey: "claudeRateLimitEnabled")
+        self.appTheme = AppTheme.load()
 
         // Self-heal: if capture was enabled but a claude-hud upgrade or
         // `/statusline` clobbered our wrapper, silently re-assert it.

--- a/VibeUsage/Models/ThemePalette.swift
+++ b/VibeUsage/Models/ThemePalette.swift
@@ -1,0 +1,161 @@
+import SwiftUI
+import VibeUsageCore
+
+extension AppTheme {
+    var palette: ThemePalette {
+        switch self {
+        case .dark:
+            return .dark
+        case .light:
+            return .light
+        case .grass:
+            return .grass
+        case .gold:
+            return .gold
+        }
+    }
+
+    var colorScheme: ColorScheme {
+        self == .dark ? .dark : .light
+    }
+}
+
+struct ThemePalette {
+    let windowBackground: Color
+    let background: Color
+    let card: Color
+    let control: Color
+    let controlHover: Color
+    let border: Color
+    let strongBorder: Color
+    let primaryText: Color
+    let secondaryText: Color
+    let tertiaryText: Color
+    let mutedText: Color
+    let selectedBackground: Color
+    let selectedText: Color
+    let accent: Color
+    let secondaryAccent: Color
+    let link: Color
+    let success: Color
+    let warning: Color
+    let danger: Color
+    let tooltipBackground: Color
+    let chartInput: Color
+    let chartOutput: Color
+    let chartNeutral: Color
+    let chartOther: Color
+    let progressTrack: Color
+
+    static let dark = ThemePalette(
+        windowBackground: Color(white: 0.04),
+        background: Color(white: 0.04),
+        card: Color(white: 0.09),
+        control: Color(white: 0.12),
+        controlHover: Color(white: 0.28),
+        border: Color(white: 0.16),
+        strongBorder: Color(white: 0.22),
+        primaryText: .white,
+        secondaryText: Color(white: 0.63),
+        tertiaryText: Color(white: 0.50),
+        mutedText: Color(white: 0.38),
+        selectedBackground: .white,
+        selectedText: .black,
+        accent: Color(red: 0.20, green: 0.80, blue: 0.50),
+        secondaryAccent: Color(red: 0.38, green: 0.60, blue: 1.00),
+        link: Color(red: 0.40, green: 0.70, blue: 1.00),
+        success: Color(red: 0.20, green: 0.80, blue: 0.50),
+        warning: Color(red: 0.96, green: 0.62, blue: 0.04),
+        danger: Color(red: 0.94, green: 0.27, blue: 0.27),
+        tooltipBackground: .black,
+        chartInput: Color(red: 0.20, green: 0.80, blue: 0.50),
+        chartOutput: Color(red: 0.38, green: 0.60, blue: 1.00),
+        chartNeutral: Color(white: 0.50),
+        chartOther: Color(white: 0.32),
+        progressTrack: Color(white: 0.14)
+    )
+
+    static let light = ThemePalette(
+        windowBackground: Color(red: 0.96, green: 0.97, blue: 0.98),
+        background: Color(red: 0.96, green: 0.97, blue: 0.98),
+        card: .white,
+        control: Color(red: 0.90, green: 0.92, blue: 0.94),
+        controlHover: Color(red: 0.81, green: 0.85, blue: 0.89),
+        border: Color(red: 0.80, green: 0.84, blue: 0.88),
+        strongBorder: Color(red: 0.68, green: 0.73, blue: 0.78),
+        primaryText: Color(red: 0.09, green: 0.12, blue: 0.16),
+        secondaryText: Color(red: 0.32, green: 0.37, blue: 0.43),
+        tertiaryText: Color(red: 0.45, green: 0.50, blue: 0.56),
+        mutedText: Color(red: 0.55, green: 0.60, blue: 0.66),
+        selectedBackground: Color(red: 0.12, green: 0.17, blue: 0.23),
+        selectedText: .white,
+        accent: Color(red: 0.05, green: 0.58, blue: 0.34),
+        secondaryAccent: Color(red: 0.16, green: 0.43, blue: 0.85),
+        link: Color(red: 0.13, green: 0.38, blue: 0.78),
+        success: Color(red: 0.05, green: 0.58, blue: 0.34),
+        warning: Color(red: 0.78, green: 0.46, blue: 0.02),
+        danger: Color(red: 0.82, green: 0.16, blue: 0.16),
+        tooltipBackground: Color(red: 0.10, green: 0.12, blue: 0.15),
+        chartInput: Color(red: 0.05, green: 0.58, blue: 0.34),
+        chartOutput: Color(red: 0.16, green: 0.43, blue: 0.85),
+        chartNeutral: Color(red: 0.55, green: 0.60, blue: 0.66),
+        chartOther: Color(red: 0.65, green: 0.69, blue: 0.74),
+        progressTrack: Color(red: 0.86, green: 0.89, blue: 0.92)
+    )
+
+    static let grass = ThemePalette(
+        windowBackground: Color(red: 0.93, green: 0.97, blue: 0.93),
+        background: Color(red: 0.93, green: 0.97, blue: 0.93),
+        card: Color(red: 0.98, green: 1.00, blue: 0.97),
+        control: Color(red: 0.84, green: 0.91, blue: 0.82),
+        controlHover: Color(red: 0.73, green: 0.84, blue: 0.70),
+        border: Color(red: 0.72, green: 0.82, blue: 0.70),
+        strongBorder: Color(red: 0.56, green: 0.70, blue: 0.54),
+        primaryText: Color(red: 0.10, green: 0.20, blue: 0.13),
+        secondaryText: Color(red: 0.27, green: 0.39, blue: 0.29),
+        tertiaryText: Color(red: 0.42, green: 0.54, blue: 0.43),
+        mutedText: Color(red: 0.54, green: 0.64, blue: 0.54),
+        selectedBackground: Color(red: 0.16, green: 0.43, blue: 0.22),
+        selectedText: .white,
+        accent: Color(red: 0.12, green: 0.55, blue: 0.27),
+        secondaryAccent: Color(red: 0.22, green: 0.50, blue: 0.64),
+        link: Color(red: 0.12, green: 0.44, blue: 0.28),
+        success: Color(red: 0.12, green: 0.55, blue: 0.27),
+        warning: Color(red: 0.70, green: 0.50, blue: 0.06),
+        danger: Color(red: 0.78, green: 0.18, blue: 0.15),
+        tooltipBackground: Color(red: 0.12, green: 0.18, blue: 0.13),
+        chartInput: Color(red: 0.12, green: 0.55, blue: 0.27),
+        chartOutput: Color(red: 0.22, green: 0.50, blue: 0.64),
+        chartNeutral: Color(red: 0.54, green: 0.64, blue: 0.54),
+        chartOther: Color(red: 0.66, green: 0.74, blue: 0.63),
+        progressTrack: Color(red: 0.83, green: 0.89, blue: 0.81)
+    )
+
+    static let gold = ThemePalette(
+        windowBackground: Color(red: 0.98, green: 0.96, blue: 0.90),
+        background: Color(red: 0.98, green: 0.96, blue: 0.90),
+        card: Color(red: 1.00, green: 0.99, blue: 0.95),
+        control: Color(red: 0.92, green: 0.86, blue: 0.72),
+        controlHover: Color(red: 0.82, green: 0.74, blue: 0.57),
+        border: Color(red: 0.83, green: 0.76, blue: 0.60),
+        strongBorder: Color(red: 0.68, green: 0.57, blue: 0.36),
+        primaryText: Color(red: 0.23, green: 0.17, blue: 0.08),
+        secondaryText: Color(red: 0.43, green: 0.34, blue: 0.18),
+        tertiaryText: Color(red: 0.56, green: 0.47, blue: 0.29),
+        mutedText: Color(red: 0.66, green: 0.58, blue: 0.40),
+        selectedBackground: Color(red: 0.55, green: 0.37, blue: 0.10),
+        selectedText: .white,
+        accent: Color(red: 0.70, green: 0.46, blue: 0.08),
+        secondaryAccent: Color(red: 0.21, green: 0.46, blue: 0.72),
+        link: Color(red: 0.55, green: 0.36, blue: 0.08),
+        success: Color(red: 0.20, green: 0.55, blue: 0.25),
+        warning: Color(red: 0.78, green: 0.47, blue: 0.04),
+        danger: Color(red: 0.78, green: 0.18, blue: 0.14),
+        tooltipBackground: Color(red: 0.18, green: 0.13, blue: 0.06),
+        chartInput: Color(red: 0.70, green: 0.46, blue: 0.08),
+        chartOutput: Color(red: 0.21, green: 0.46, blue: 0.72),
+        chartNeutral: Color(red: 0.66, green: 0.58, blue: 0.40),
+        chartOther: Color(red: 0.74, green: 0.66, blue: 0.48),
+        progressTrack: Color(red: 0.90, green: 0.84, blue: 0.69)
+    )
+}

--- a/VibeUsage/Services/SettingsWindowController.swift
+++ b/VibeUsage/Services/SettingsWindowController.swift
@@ -29,7 +29,7 @@ final class SettingsWindowController: NSObject, NSWindowDelegate {
         let window = NSWindow(contentViewController: hostingController)
         window.title = "Vibe Usage Settings"
         window.styleMask = [.titled, .closable]
-        window.setContentSize(NSSize(width: 460, height: 480))
+        window.setContentSize(NSSize(width: 460, height: 540))
         window.center()
         window.isReleasedWhenClosed = false
         window.delegate = self

--- a/VibeUsage/Views/BarChartView.swift
+++ b/VibeUsage/Views/BarChartView.swift
@@ -165,13 +165,14 @@ struct BarChartView: View {
 
     var body: some View {
         @Bindable var state = appState
+        let palette = appState.appTheme.palette
 
         VStack(spacing: 0) {
             // Header
             HStack {
                 Text(isHourly ? "每小时趋势" : "每日趋势")
                     .font(.system(size: 13, weight: .medium))
-                    .foregroundStyle(Color(white: 0.63))
+                    .foregroundStyle(palette.secondaryText)
                 Spacer()
                 HStack(spacing: 2) {
                     ForEach(ChartMode.allCases, id: \.self) { mode in
@@ -180,15 +181,15 @@ struct BarChartView: View {
                                 .font(.system(size: 11, weight: state.chartMode == mode ? .medium : .regular))
                                 .padding(.horizontal, 10)
                                 .padding(.vertical, 4)
-                                .background(state.chartMode == mode ? Color(white: 0.28) : Color.clear)
-                                .foregroundStyle(state.chartMode == mode ? Color.white : Color(white: 0.5))
+                                .background(state.chartMode == mode ? palette.controlHover : Color.clear)
+                                .foregroundStyle(state.chartMode == mode ? palette.primaryText : palette.tertiaryText)
                                 .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
                     }
                 }
                 .padding(2)
-                .background(Color(white: 0.16))
+                .background(palette.control)
                 .clipShape(Capsule())
             }
             .padding(.bottom, 14)
@@ -210,17 +211,18 @@ struct BarChartView: View {
             )
         }
         .padding(14)
-        .background(Color(white: 0.09))
+        .background(palette.card)
         .cornerRadius(4)
         .overlay(
             RoundedRectangle(cornerRadius: 4)
-                .stroke(Color(white: 0.16), lineWidth: 1)
+                .stroke(palette.border, lineWidth: 1)
         )
     }
 
 }
 
 private struct ChartContent: View {
+    @Environment(AppState.self) private var appState
     let data: [BarData]
     let chartMode: ChartMode
     let isHourly: Bool
@@ -233,6 +235,8 @@ private struct ChartContent: View {
     @State private var scroll = ScrollWatcher()
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         VStack(spacing: 0) {
             // Chart
             HStack(alignment: .bottom, spacing: 6) {
@@ -249,13 +253,13 @@ private struct ChartContent: View {
                         }
                     }
                     .font(.system(size: 11, design: .monospaced))
-                    .foregroundStyle(Color(white: 0.38))
+                    .foregroundStyle(palette.mutedText)
                     .lineLimit(1)
                     .minimumScaleFactor(0.7)
                     Spacer()
                     Text("0")
                         .font(.system(size: 11, design: .monospaced))
-                        .foregroundStyle(Color(white: 0.38))
+                        .foregroundStyle(palette.mutedText)
                         .lineLimit(1)
                 }
                 .frame(width: 44)
@@ -271,23 +275,23 @@ private struct ChartContent: View {
                                 let outputH = CGFloat(bar.output) / CGFloat(maxTotal) * 150
                                 // Output (top, white)
                                 Rectangle()
-                                    .fill(Color.white.opacity(0.9))
+                                    .fill(palette.chartOutput)
                                     .frame(height: outputH)
                                     .clipShape(UnevenRoundedRectangle(topLeadingRadius: 2, topTrailingRadius: 2))
                                 // Input (bottom, zinc)
                                 Rectangle()
-                                    .fill(Color(white: 0.5))
+                                    .fill(palette.chartInput)
                                     .frame(height: inputH)
                             case .cost:
                                 let costH = CGFloat(bar.cost) / CGFloat(maxCost) * 150
                                 Rectangle()
-                                    .fill(Color(red: 0.2, green: 0.8, blue: 0.5))
+                                    .fill(palette.accent)
                                     .frame(height: costH)
                                     .clipShape(UnevenRoundedRectangle(topLeadingRadius: 2, topTrailingRadius: 2))
                             case .activeTime:
                                 let activeH = CGFloat(bar.activeMinutes) / CGFloat(maxActiveMinutes) * 150
                                 Rectangle()
-                                    .fill(Color(red: 0.38, green: 0.6, blue: 1.0))
+                                    .fill(palette.secondaryAccent)
                                     .frame(height: activeH)
                                     .clipShape(UnevenRoundedRectangle(topLeadingRadius: 2, topTrailingRadius: 2))
                             }
@@ -349,7 +353,7 @@ private struct ChartContent: View {
                         if index % labelInterval == 0 {
                             Text(isHourly ? Formatters.formatHourShort(bar.id) : Formatters.formatDateShort(bar.id))
                                 .font(.system(size: 11))
-                                .foregroundStyle(Color(white: 0.5))
+                                .foregroundStyle(palette.tertiaryText)
                                 .lineLimit(1)
                                 .fixedSize()
                         } else {
@@ -372,36 +376,38 @@ private struct ChartContent: View {
 
     @ViewBuilder
     private func tooltip(for bar: BarData) -> some View {
+        let palette = appState.appTheme.palette
+
         VStack(alignment: .leading, spacing: 3) {
             Text(isHourly ? Formatters.formatHourShort(bar.id) : Formatters.formatDateShort(bar.id))
-                .foregroundStyle(.white)
+                .foregroundStyle(palette.primaryText)
                 .fontWeight(.medium)
 
             switch chartMode {
             case .token:
                 Text("总 Token: \(Formatters.formatNumber(bar.total))")
-                    .foregroundStyle(Color(white: 0.8))
+                    .foregroundStyle(palette.secondaryText)
                 HStack(spacing: 8) {
                     Text("输入: \(Formatters.formatNumber(bar.input))")
-                        .foregroundStyle(Color(white: 0.5))
+                        .foregroundStyle(palette.tertiaryText)
                     Text("输出: \(Formatters.formatNumber(bar.output))")
-                        .foregroundStyle(Color(white: 0.5))
+                        .foregroundStyle(palette.tertiaryText)
                 }
                 Text("费用: \(Formatters.formatCost(bar.cost))")
-                    .foregroundStyle(Color(red: 0.2, green: 0.8, blue: 0.5))
+                    .foregroundStyle(palette.accent)
             case .cost:
                 Text("费用: \(Formatters.formatCost(bar.cost))")
-                    .foregroundStyle(Color(red: 0.2, green: 0.8, blue: 0.5))
+                    .foregroundStyle(palette.accent)
             case .activeTime:
                 Text("活跃时长: \(Formatters.formatDuration(Int(bar.activeMinutes * 60)))")
-                    .foregroundStyle(Color(red: 0.38, green: 0.6, blue: 1.0))
+                    .foregroundStyle(palette.secondaryAccent)
             }
         }
         .font(.system(size: 11))
         .padding(8)
-        .background(Color.black)
+        .background(palette.tooltipBackground)
         .cornerRadius(4)
-        .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color(white: 0.2), lineWidth: 0.5))
+        .overlay(RoundedRectangle(cornerRadius: 4).stroke(palette.strongBorder, lineWidth: 0.5))
         .shadow(color: .black.opacity(0.5), radius: 4, y: 2)
         .fixedSize()
     }

--- a/VibeUsage/Views/DistributionChartsView.swift
+++ b/VibeUsage/Views/DistributionChartsView.swift
@@ -62,7 +62,7 @@ struct DistributionChartsView: View {
             Color(red: 0.55, green: 0.36, blue: 0.96),
             Color(red: 0.93, green: 0.30, blue: 0.60),
         ]
-        let otherColor = Color(white: 0.32)
+        let otherColor = appState.appTheme.palette.chartOther
 
         var slices: [SliceData] = []
         var otherTokens = 0
@@ -114,6 +114,7 @@ enum MetricMode {
 // MARK: - Donut Card
 
 private struct DonutCardView: View {
+    @Environment(AppState.self) private var appState
     let title: String
     let icon: String
     let slices: [SliceData]
@@ -127,15 +128,17 @@ private struct DonutCardView: View {
     }
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         VStack(alignment: .leading, spacing: 10) {
             HStack(spacing: 0) {
                 HStack(spacing: 5) {
                     Image(systemName: icon)
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(white: 0.5))
+                        .foregroundStyle(palette.tertiaryText)
                     Text(title)
                         .font(.system(size: 13, weight: .medium))
-                        .foregroundStyle(Color(white: 0.63))
+                        .foregroundStyle(palette.secondaryText)
                 }
                 Spacer()
                 MetricToggleView(mode: $mode)
@@ -144,7 +147,7 @@ private struct DonutCardView: View {
             if slices.isEmpty || total == 0 {
                 Text("暂无数据")
                     .font(.system(size: 12))
-                    .foregroundStyle(Color(white: 0.38))
+                    .foregroundStyle(palette.mutedText)
                     .frame(maxWidth: .infinity)
                     .frame(height: 80)
             } else {
@@ -160,16 +163,16 @@ private struct DonutCardView: View {
                                     .frame(width: 7, height: 7)
                                 Text(slice.label)
                                     .font(.system(size: 11))
-                                    .foregroundStyle(Color(white: 0.7))
+                                    .foregroundStyle(palette.secondaryText)
                                     .lineLimit(1)
                                     .truncationMode(.tail)
                                 Spacer(minLength: 4)
                                 Text(valueText(slice))
                                     .font(.system(size: 11, design: .monospaced))
-                                    .foregroundStyle(Color(white: 0.55))
+                                    .foregroundStyle(palette.tertiaryText)
                                 Text(percentage(slice))
                                     .font(.system(size: 11, design: .monospaced))
-                                    .foregroundStyle(Color(white: 0.38))
+                                    .foregroundStyle(palette.mutedText)
                                     .frame(width: 42, alignment: .trailing)
                             }
                         }
@@ -179,9 +182,9 @@ private struct DonutCardView: View {
         }
         .padding(14)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
-        .background(Color(white: 0.09))
+        .background(palette.card)
         .cornerRadius(4)
-        .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color(white: 0.16), lineWidth: 1))
+        .overlay(RoundedRectangle(cornerRadius: 4).stroke(palette.border, lineWidth: 1))
     }
 
     private func valueText(_ slice: SliceData) -> String {
@@ -203,28 +206,34 @@ private struct DonutCardView: View {
 // MARK: - Metric Toggle
 
 private struct MetricToggleView: View {
+    @Environment(AppState.self) private var appState
     @Binding var mode: MetricMode
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         HStack(spacing: 2) {
             toggleButton(.tokens)
             toggleButton(.cost)
         }
         .padding(2)
-        .background(Color(white: 0.16))
+        .background(palette.control)
         .clipShape(Capsule())
     }
 
+    @ViewBuilder
     private func toggleButton(_ m: MetricMode) -> some View {
+        let palette = appState.appTheme.palette
+
         Button {
             mode = m
         } label: {
             Text(m.label)
                 .font(.system(size: 11, weight: mode == m ? .medium : .regular))
-                .foregroundStyle(mode == m ? .white : Color(white: 0.5))
+                .foregroundStyle(mode == m ? palette.primaryText : palette.tertiaryText)
                 .padding(.horizontal, 9)
                 .padding(.vertical, 3)
-                .background(mode == m ? Color(white: 0.28) : Color.clear)
+                .background(mode == m ? palette.controlHover : Color.clear)
                 .clipShape(Capsule())
         }
         .buttonStyle(.plain)
@@ -234,6 +243,7 @@ private struct MetricToggleView: View {
 // MARK: - Donut Shape
 
 private struct DonutShape: View {
+    @Environment(AppState.self) private var appState
     let slices: [SliceData]
     let mode: MetricMode
     let total: Double
@@ -241,9 +251,11 @@ private struct DonutShape: View {
     private let lineWidth: CGFloat = 11
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         ZStack {
             Circle()
-                .stroke(Color(white: 0.16), lineWidth: lineWidth)
+                .stroke(palette.border, lineWidth: lineWidth)
 
             Canvas { context, size in
                 let center = CGPoint(x: size.width / 2, y: size.height / 2)
@@ -268,10 +280,10 @@ private struct DonutShape: View {
             VStack(spacing: 1) {
                 Text(mode == .tokens ? "Tokens" : "预估")
                     .font(.system(size: 9))
-                    .foregroundStyle(Color(white: 0.45))
+                    .foregroundStyle(palette.mutedText)
                 Text(centerLabel)
                     .font(.system(size: 12, weight: .bold, design: .monospaced))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(palette.primaryText)
                     .lineLimit(1)
                     .minimumScaleFactor(0.6)
             }

--- a/VibeUsage/Views/FilterTagsView.swift
+++ b/VibeUsage/Views/FilterTagsView.swift
@@ -23,6 +23,7 @@ struct FilterTagsView: View {
 
     var body: some View {
         @Bindable var state = appState
+        let palette = appState.appTheme.palette
 
         VStack(alignment: .leading, spacing: 8) {
             // Date / time range row
@@ -33,7 +34,7 @@ struct FilterTagsView: View {
                     Text("日期")
                         .font(.system(size: 12))
                 }
-                .foregroundStyle(Color(white: 0.5))
+                .foregroundStyle(palette.tertiaryText)
                 .frame(width: 48, alignment: .trailing)
                 .padding(.vertical, 3)
 
@@ -55,8 +56,8 @@ struct FilterTagsView: View {
                                 .font(.system(size: 12, weight: isActive ? .medium : .regular))
                                 .padding(.horizontal, 9)
                                 .padding(.vertical, 3)
-                                .background(isActive ? Color.white : Color(white: 0.16))
-                                .foregroundStyle(isActive ? Color.black : Color(white: 0.63))
+                                .background(isActive ? palette.selectedBackground : palette.control)
+                                .foregroundStyle(isActive ? palette.selectedText : palette.secondaryText)
                                 .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
@@ -102,7 +103,7 @@ struct FilterTagsView: View {
                         Text("模型")
                             .font(.system(size: 12))
                     }
-                    .foregroundStyle(Color(white: 0.5))
+                    .foregroundStyle(palette.tertiaryText)
                     .frame(width: 48, alignment: .trailing)
                     .padding(.vertical, 3)
 
@@ -128,8 +129,8 @@ struct FilterTagsView: View {
                                     .font(.system(size: 12))
                                     .padding(.horizontal, 9)
                                     .padding(.vertical, 3)
-                                    .background(allSelected ? Color.white : (someSelected ? Color(white: 0.28) : Color(white: 0.16)))
-                                    .foregroundStyle(allSelected ? Color.black : (someSelected ? Color.white : Color(white: 0.63)))
+                                    .background(allSelected ? palette.selectedBackground : (someSelected ? palette.controlHover : palette.control))
+                                    .foregroundStyle(allSelected ? palette.selectedText : (someSelected ? palette.primaryText : palette.secondaryText))
                                     .clipShape(Capsule())
                             }
                             .buttonStyle(.plain)
@@ -156,8 +157,8 @@ struct FilterTagsView: View {
                                             .font(.system(size: 12))
                                             .padding(.horizontal, 9)
                                             .padding(.vertical, 3)
-                                            .background(isActive ? Color.white : Color(white: 0.16))
-                                            .foregroundStyle(isActive ? Color.black : Color(white: 0.63))
+                                            .background(isActive ? palette.selectedBackground : palette.control)
+                                            .foregroundStyle(isActive ? palette.selectedText : palette.secondaryText)
                                             .clipShape(Capsule())
                                     }
                                     .buttonStyle(.plain)
@@ -176,7 +177,7 @@ struct FilterTagsView: View {
                         Text("项目")
                             .font(.system(size: 12))
                     }
-                    .foregroundStyle(Color(white: 0.5))
+                    .foregroundStyle(palette.tertiaryText)
                     .frame(width: 48, alignment: .trailing)
                     .padding(.vertical, 3)
 
@@ -187,10 +188,10 @@ struct FilterTagsView: View {
                         } label: {
                             Image(systemName: showProjects ? "eye" : "eye.slash")
                                 .font(.system(size: 12))
-                                .foregroundStyle(Color(white: showProjects ? 0.6 : 0.35))
+                                .foregroundStyle(showProjects ? palette.secondaryText : palette.mutedText)
                                 .padding(.horizontal, 7)
                                 .padding(.vertical, 3)
-                                .background(Color(white: 0.16))
+                                .background(palette.control)
                                 .clipShape(Capsule())
                         }
                         .buttonStyle(.plain)
@@ -217,8 +218,8 @@ struct FilterTagsView: View {
                                         .font(.system(size: 12))
                                         .padding(.horizontal, 9)
                                         .padding(.vertical, 3)
-                                        .background(isActive ? Color.white : Color(white: 0.16))
-                                        .foregroundStyle(isActive ? Color.black : Color(white: 0.63))
+                                        .background(isActive ? palette.selectedBackground : palette.control)
+                                        .foregroundStyle(isActive ? palette.selectedText : palette.secondaryText)
                                         .clipShape(Capsule())
                                 }
                                 .buttonStyle(.plain)
@@ -234,7 +235,7 @@ struct FilterTagsView: View {
                 }
                 .buttonStyle(.plain)
                 .font(.system(size: 12))
-                .foregroundStyle(.red.opacity(0.8))
+                .foregroundStyle(palette.danger.opacity(0.8))
                 .padding(.leading, 56)
             }
         }
@@ -248,6 +249,7 @@ struct FilterTagsView: View {
         }
     }
 
+    @ViewBuilder
     private func filterRow(
         icon: String,
         label: String,
@@ -257,6 +259,8 @@ struct FilterTagsView: View {
         eyeToggle: (() -> Void)? = nil,
         toggle: @escaping (String) -> Void
     ) -> some View {
+        let palette = appState.appTheme.palette
+
         HStack(alignment: .top, spacing: 8) {
             HStack(spacing: 4) {
                 Image(systemName: icon)
@@ -264,7 +268,7 @@ struct FilterTagsView: View {
                 Text(label)
                     .font(.system(size: 12))
             }
-            .foregroundStyle(Color(white: 0.5))
+            .foregroundStyle(palette.tertiaryText)
             .frame(width: 48, alignment: .trailing)
             .padding(.vertical, 3) // match tag vertical padding for baseline alignment
 
@@ -274,7 +278,7 @@ struct FilterTagsView: View {
                 } label: {
                     Image(systemName: masked ? "eye.slash" : "eye")
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(white: masked ? 0.35 : 0.6))
+                        .foregroundStyle(masked ? palette.mutedText : palette.secondaryText)
                         .frame(height: 12 + 6) // match tag height (font 12 + padding 3*2)
                 }
                 .buttonStyle(.plain)
@@ -291,8 +295,8 @@ struct FilterTagsView: View {
                             .font(.system(size: 12))
                             .padding(.horizontal, 9)
                             .padding(.vertical, 3)
-                            .background(isActive ? Color.white : Color(white: 0.16))
-                            .foregroundStyle(isActive ? Color.black : Color(white: 0.63))
+                            .background(isActive ? palette.selectedBackground : palette.control)
+                            .foregroundStyle(isActive ? palette.selectedText : palette.secondaryText)
                             .clipShape(Capsule())
                     }
                     .buttonStyle(.plain)
@@ -347,15 +351,18 @@ struct FlowLayout: Layout {
 }
 
 struct HoverChevronButton: View {
+    @Environment(AppState.self) private var appState
     let isExpanded: Bool
     let action: () -> Void
     @State private var isHovered = false
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         Button(action: action) {
             Image(systemName: isExpanded ? "chevron.left" : "chevron.right")
                 .font(.system(size: 9))
-                .foregroundStyle(isHovered ? Color.white : Color(white: 0.38))
+                .foregroundStyle(isHovered ? palette.primaryText : palette.mutedText)
                 .frame(height: 18)
                 .padding(.horizontal, 4)
                 .contentShape(Rectangle())

--- a/VibeUsage/Views/PopoverView.swift
+++ b/VibeUsage/Views/PopoverView.swift
@@ -14,6 +14,10 @@ struct PopoverView: View {
         case awaitingApproval
     }
 
+    private var palette: ThemePalette {
+        appState.appTheme.palette
+    }
+
     var body: some View {
         VStack(spacing: 0) {
             if !appState.isConfigured {
@@ -23,7 +27,8 @@ struct PopoverView: View {
             }
         }
         .frame(width: 520)
-        .background(Color(white: 0.04))
+        .background(palette.background)
+        .preferredColorScheme(appState.appTheme.colorScheme)
     }
 
     // MARK: - Unconfigured State
@@ -34,7 +39,7 @@ struct PopoverView: View {
             HStack(spacing: 6) {
                 Text("Vibe Usage")
                     .font(.system(size: 15, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(palette.primaryText)
                 if AppConfig.isDev {
                     Text("DEBUG")
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
@@ -50,33 +55,33 @@ struct PopoverView: View {
                 .padding(.bottom, 8)
 
             Divider()
-                .background(Color(white: 0.16))
+                .background(palette.border)
 
             VStack(alignment: .leading, spacing: 16) {
                 if let pendingUserCode {
                     HStack(alignment: .top, spacing: 8) {
                         Image(systemName: "info.circle")
                             .font(.system(size: 12))
-                            .foregroundStyle(Color(white: 0.5))
+                            .foregroundStyle(palette.tertiaryText)
                         Text("请确认浏览器中显示的验证码与下方一致")
                             .font(.system(size: 12))
-                            .foregroundStyle(Color(white: 0.7))
+                            .foregroundStyle(palette.secondaryText)
                     }
                     .padding(.horizontal, 10)
                     .padding(.vertical, 8)
                     .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(Color(white: 0.06))
-                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color(white: 0.16), lineWidth: 1))
+                    .background(palette.card)
+                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(palette.border, lineWidth: 1))
                     .cornerRadius(4)
 
                     VStack(alignment: .leading, spacing: 6) {
                         Text("验证码")
                             .font(.system(size: 10, weight: .medium))
-                            .foregroundStyle(Color(white: 0.5))
+                            .foregroundStyle(palette.tertiaryText)
                             .textCase(.uppercase)
                         Text(pendingUserCode)
                             .font(.system(size: 22, weight: .semibold, design: .monospaced))
-                            .foregroundStyle(.white)
+                            .foregroundStyle(palette.primaryText)
                             .tracking(3)
                     }
                 }
@@ -84,7 +89,7 @@ struct PopoverView: View {
                 if let setupError {
                     Text(setupError)
                         .font(.system(size: 12))
-                        .foregroundStyle(.red)
+                        .foregroundStyle(palette.danger)
                 }
 
                 Button {
@@ -95,7 +100,7 @@ struct PopoverView: View {
                         if deviceFlowState == .awaitingApproval {
                             ProgressView()
                                 .controlSize(.small)
-                                .tint(.black)
+                                .tint(palette.selectedText)
                         }
                         Text(deviceFlowState == .awaitingApproval ? "等待浏览器确认…" : "登录并链接数据")
                             .font(.system(size: 13, weight: .medium))
@@ -104,8 +109,8 @@ struct PopoverView: View {
                     .padding(.vertical, 8)
                 }
                 .buttonStyle(.borderedProminent)
-                .tint(.white)
-                .foregroundStyle(.black)
+                .tint(palette.selectedBackground)
+                .foregroundStyle(palette.selectedText)
                 .disabled(deviceFlowState == .awaitingApproval)
 
                 if deviceFlowState == .awaitingApproval {
@@ -118,7 +123,7 @@ struct PopoverView: View {
                             .padding(.vertical, 6)
                     }
                     .buttonStyle(.plain)
-                    .foregroundStyle(Color(white: 0.6))
+                    .foregroundStyle(palette.secondaryText)
                 }
             }
             .padding(16)
@@ -210,7 +215,7 @@ struct PopoverView: View {
                 .padding(.bottom, 8)
 
             Divider()
-                .background(Color(white: 0.16))
+                .background(palette.border)
 
             // Scrollable content
             ScrollView(.vertical, showsIndicators: false) {
@@ -231,7 +236,7 @@ struct PopoverView: View {
                         RateLimitCardView()
                             .zIndex(1)
                         Divider()
-                            .background(Color(white: 0.16))
+                            .background(palette.border)
                             .padding(.vertical, 2)
                         FilterTagsView()
                         SummaryCardsView()
@@ -244,7 +249,7 @@ struct PopoverView: View {
             .frame(height: 560)
 
             Divider()
-                .background(Color(white: 0.16))
+                .background(palette.border)
 
             // Footer
             footerBar
@@ -260,7 +265,7 @@ struct PopoverView: View {
             HStack(spacing: 6) {
                 Text("Vibe Usage")
                     .font(.system(size: 15, weight: .bold))
-                    .foregroundStyle(.white)
+                    .foregroundStyle(palette.primaryText)
                 if AppConfig.isDev {
                     Text("DEBUG")
                         .font(.system(size: 10, weight: .bold, design: .monospaced))
@@ -283,12 +288,12 @@ struct PopoverView: View {
             } label: {
                 Text("设置")
                     .font(.system(size: 11))
-                    .foregroundStyle(Color(white: 0.5))
+                    .foregroundStyle(palette.tertiaryText)
                     .padding(.horizontal, 8)
                     .padding(.vertical, 4)
-                    .background(Color(white: 0.12))
+                    .background(palette.control)
                     .cornerRadius(4)
-                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color(white: 0.18), lineWidth: 0.5))
+                    .overlay(RoundedRectangle(cornerRadius: 4).stroke(palette.border, lineWidth: 0.5))
             }
             .buttonStyle(.plain)
         }
@@ -306,12 +311,12 @@ struct PopoverView: View {
                 Image(systemName: "arrow.up.right")
                     .font(.system(size: 9, weight: .medium))
             }
-            .foregroundStyle(Color(white: 0.5))
+            .foregroundStyle(palette.tertiaryText)
             .padding(.horizontal, 8)
             .padding(.vertical, 4)
-            .background(Color(white: 0.12))
+            .background(palette.control)
             .cornerRadius(4)
-            .overlay(RoundedRectangle(cornerRadius: 4).stroke(Color(white: 0.18), lineWidth: 0.5))
+            .overlay(RoundedRectangle(cornerRadius: 4).stroke(palette.border, lineWidth: 0.5))
         }
         .buttonStyle(.plain)
     }
@@ -326,37 +331,37 @@ struct PopoverView: View {
                 case .idle:
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(red: 0.2, green: 0.8, blue: 0.5))
+                        .foregroundStyle(palette.success)
                 case .syncing:
                     ProgressView()
                         .controlSize(.mini)
                 case .success:
                     Image(systemName: "checkmark.circle.fill")
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(red: 0.2, green: 0.8, blue: 0.5))
+                        .foregroundStyle(palette.success)
                 case .error:
                     Image(systemName: "exclamationmark.circle.fill")
                         .font(.system(size: 11))
-                        .foregroundStyle(.red)
+                        .foregroundStyle(palette.danger)
                 }
 
                 if appState.syncStatus == .syncing {
                     Text("同步中...")
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(white: 0.38))
+                        .foregroundStyle(palette.mutedText)
                 } else if case .error(let msg) = appState.syncStatus {
                     Text(msg)
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(white: 0.38))
+                        .foregroundStyle(palette.mutedText)
                         .lineLimit(1)
                 } else if let lastSync = appState.lastSyncTime {
                     Text("上次同步: \(Formatters.formatRelativeTime(lastSync))")
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(white: 0.38))
+                        .foregroundStyle(palette.mutedText)
                 } else {
                     Text("就绪")
                         .font(.system(size: 11))
-                        .foregroundStyle(Color(white: 0.38))
+                        .foregroundStyle(palette.mutedText)
                 }
             }
 
@@ -375,7 +380,7 @@ struct PopoverView: View {
                         Text("发现更新")
                             .font(.system(size: 11, weight: .medium))
                     }
-                    .foregroundStyle(Color(red: 0.4, green: 0.7, blue: 1.0))
+                    .foregroundStyle(palette.link)
                 }
                 .buttonStyle(.plain)
                 .padding(.trailing, 12)
@@ -398,7 +403,7 @@ struct PopoverView: View {
                     Text("更新数据")
                         .font(.system(size: 11))
                 }
-                .foregroundStyle(Color(white: 0.5))
+                .foregroundStyle(palette.tertiaryText)
             }
             .buttonStyle(.plain)
             .disabled(appState.syncStatus == .syncing)
@@ -413,7 +418,7 @@ struct PopoverView: View {
                     Text("关闭")
                         .font(.system(size: 11))
                 }
-                .foregroundStyle(Color(white: 0.5))
+                .foregroundStyle(palette.tertiaryText)
             }
             .buttonStyle(.plain)
             .padding(.leading, 12)
@@ -428,7 +433,7 @@ struct PopoverView: View {
                 .controlSize(.regular)
             Text("加载数据中...")
                 .font(.system(size: 13))
-                .foregroundStyle(Color(white: 0.5))
+                .foregroundStyle(palette.tertiaryText)
         }
         .frame(maxWidth: .infinity)
         .frame(height: 200)
@@ -438,13 +443,13 @@ struct PopoverView: View {
         VStack(spacing: 12) {
             Image(systemName: "tray")
                 .font(.system(size: 32))
-                .foregroundStyle(Color(white: 0.3))
+                .foregroundStyle(palette.mutedText)
             Text("暂无数据")
                 .font(.system(size: 15, weight: .medium))
-                .foregroundStyle(Color(white: 0.5))
+                .foregroundStyle(palette.tertiaryText)
             Text("使用 AI 编程工具后数据将自动同步")
                 .font(.system(size: 13))
-                .foregroundStyle(Color(white: 0.38))
+                .foregroundStyle(palette.mutedText)
         }
         .frame(maxWidth: .infinity)
         .frame(height: 200)

--- a/VibeUsage/Views/RateLimitCardView.swift
+++ b/VibeUsage/Views/RateLimitCardView.swift
@@ -46,14 +46,17 @@ struct RateLimitCardView: View {
     /// Single-line whisper shown when neither Codex nor Claude has any data.
     /// Mirrors the generic "feature exists; use a tool to populate" hint without
     /// reserving the full card row's vertical space.
+    @ViewBuilder
     private var noticeBar: some View {
+        let palette = appState.appTheme.palette
+
         HStack(spacing: 6) {
             Image(systemName: "info.circle")
                 .font(.system(size: 10))
             Text("支持 Codex / Claude 订阅配额监控")
                 .font(.system(size: 11))
         }
-        .foregroundStyle(Color(white: 0.4))
+        .foregroundStyle(palette.mutedText)
         .frame(maxWidth: .infinity, alignment: .leading)
     }
 }
@@ -72,6 +75,8 @@ private struct ProviderCard: View {
     @State private var hoveredLabel: String? = nil
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         VStack(alignment: .leading, spacing: 10) {
             header
             content
@@ -87,31 +92,34 @@ private struct ProviderCard: View {
         // `.background` keeps them entirely behind the content.
         .background(
             RoundedRectangle(cornerRadius: 4)
-                .fill(Color(white: 0.09))
+                .fill(palette.card)
                 .overlay(
                     RoundedRectangle(cornerRadius: 4)
-                        .strokeBorder(Color(white: 0.16), lineWidth: 1)
+                        .strokeBorder(palette.border, lineWidth: 1)
                 )
         )
     }
 
     // MARK: Header
 
+    @ViewBuilder
     private var header: some View {
+        let palette = appState.appTheme.palette
+
         HStack(spacing: 6) {
             ProviderIcon(provider: snapshot.provider)
                 .frame(width: 14, height: 14)
             Text(snapshot.provider.displayName)
                 .font(.system(size: 13, weight: .semibold))
-                .foregroundStyle(.white)
+                .foregroundStyle(palette.primaryText)
             Spacer()
             if let label = snapshot.planLabel {
                 Text(label)
                     .font(.system(size: 10, weight: .medium))
-                    .foregroundStyle(Color(white: 0.55))
+                    .foregroundStyle(palette.tertiaryText)
                     .padding(.horizontal, 7)
                     .padding(.vertical, 2)
-                    .background(Color(white: 0.16))
+                    .background(palette.control)
                     .clipShape(Capsule())
             }
         }
@@ -179,6 +187,7 @@ private struct ProviderCard: View {
     @ViewBuilder
     private var quotaRows: some View {
         let rows = visibleRows
+        let palette = appState.appTheme.palette
         VStack(alignment: .leading, spacing: rowSpacing) {
             ForEach(Array(rows.enumerated()), id: \.offset) { _, row in
                 rowView(row)
@@ -187,7 +196,7 @@ private struct ProviderCard: View {
             if rows.isEmpty {
                 Text("暂无订阅配额数据")
                     .font(.system(size: 11))
-                    .foregroundStyle(Color(white: 0.45))
+                    .foregroundStyle(palette.mutedText)
             }
         }
         // The tooltip overlay attached HERE — at the rows VStack — paints
@@ -201,7 +210,7 @@ private struct ProviderCard: View {
                 TooltipView(
                     title: tooltipTitle(for: hovered),
                     tokenPercentText: win.percentText,
-                    tokenColor: ProgressBar.color(for: win.utilization),
+                    tokenColor: ProgressBar.color(for: win.utilization, palette: palette),
                     elapsedPercentText: win.elapsedPercentText,
                     remainingText: win.remainingText
                 )
@@ -252,14 +261,17 @@ private struct ProviderCard: View {
     /// The button installs it (a one-time edit to Claude Code's settings.json);
     /// thereafter reads are auth-free. Copy is kept to one plain-language line
     /// (matching the other states); an install failure replaces it inline.
+    @ViewBuilder
     private var disabledContent: some View {
+        let palette = appState.appTheme.palette
+
         HStack(spacing: 8) {
             Text(appState.claudeRateLimitInstallError ?? "读取 Claude 用量数据")
                 .font(.system(size: 11))
                 .foregroundStyle(
                     appState.claudeRateLimitInstallError != nil
-                        ? Color(red: 0.94, green: 0.27, blue: 0.27)
-                        : Color(white: 0.5)
+                        ? palette.danger
+                        : palette.tertiaryText
                 )
                 .lineLimit(1)
                 .truncationMode(.tail)
@@ -269,21 +281,24 @@ private struct ProviderCard: View {
             } label: {
                 Text("启用")
                     .font(.system(size: 12, weight: .medium))
-                    .foregroundStyle(.black)
+                    .foregroundStyle(palette.selectedText)
                     .padding(.horizontal, 12)
                     .padding(.vertical, 4)
-                    .background(Color.white)
+                    .background(palette.selectedBackground)
                     .clipShape(Capsule())
             }
             .buttonStyle(.plain)
         }
     }
 
+    @ViewBuilder
     private func messageContent(text: String, action: String) -> some View {
+        let palette = appState.appTheme.palette
+
         HStack(spacing: 8) {
             Text(text)
                 .font(.system(size: 11))
-                .foregroundStyle(Color(white: 0.5))
+                .foregroundStyle(palette.tertiaryText)
                 .lineLimit(1)
                 .truncationMode(.tail)
             Spacer(minLength: 0)
@@ -292,10 +307,10 @@ private struct ProviderCard: View {
             } label: {
                 Text(action)
                     .font(.system(size: 11))
-                    .foregroundStyle(Color(white: 0.78))
+                    .foregroundStyle(palette.secondaryText)
                     .padding(.horizontal, 10)
                     .padding(.vertical, 3)
-                    .background(Color(white: 0.16))
+                    .background(palette.control)
                     .clipShape(Capsule())
             }
             .buttonStyle(.plain)
@@ -309,6 +324,7 @@ private struct ProviderCard: View {
 /// owned here — the parent ProviderCard observes hover through `onHover`
 /// and renders the tooltip at its own layer.
 private struct QuotaRow: View {
+    @Environment(AppState.self) private var appState
     let label: String
     let window: RateLimitWindow
     let onHover: (Bool) -> Void
@@ -320,10 +336,12 @@ private struct QuotaRow: View {
     private var hasElapsed: Bool { window.elapsedPercent != nil }
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         HStack(alignment: .center, spacing: 6) {
             Text(label)
                 .font(.system(size: 12, weight: .medium, design: .monospaced))
-                .foregroundStyle(Color(white: 0.6))
+                .foregroundStyle(palette.secondaryText)
                 .frame(width: 20, alignment: .leading)
 
             if hasElapsed {
@@ -333,8 +351,8 @@ private struct QuotaRow: View {
                         .frame(height: 6)
                     ProgressBar(
                         value: window.elapsedPercent ?? 0,
-                        fill: Color(white: 0.42),
-                        background: Color(white: 0.14)
+                        fill: palette.chartNeutral,
+                        background: palette.progressTrack
                     )
                     .frame(height: 3)
                 }
@@ -343,7 +361,7 @@ private struct QuotaRow: View {
 
                 Text(window.percentText)
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundStyle(ProgressBar.color(for: window.utilization))
+                    .foregroundStyle(ProgressBar.color(for: window.utilization, palette: palette))
                     .frame(width: 36, alignment: .trailing)
             } else {
                 // Claude: no window length to derive a time bar. The reset
@@ -357,7 +375,7 @@ private struct QuotaRow: View {
 
                 Text(window.percentText)
                     .font(.system(size: 12, weight: .medium, design: .monospaced))
-                    .foregroundStyle(ProgressBar.color(for: window.utilization))
+                    .foregroundStyle(ProgressBar.color(for: window.utilization, palette: palette))
                     .frame(width: 36, alignment: .trailing)
             }
         }
@@ -371,19 +389,22 @@ private struct QuotaRow: View {
 /// column aligned with `QuotaRow` so the 7d row doesn't visually shift into
 /// the 5h slot. No progress bar, no hover state.
 private struct EmptyQuotaRow: View {
+    @Environment(AppState.self) private var appState
     let label: String
     let message: String
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         HStack(alignment: .center, spacing: 6) {
             Text(label)
                 .font(.system(size: 12, weight: .medium, design: .monospaced))
-                .foregroundStyle(Color(white: 0.4))
+                .foregroundStyle(palette.mutedText)
                 .frame(width: 20, alignment: .leading)
 
             Text(message)
                 .font(.system(size: 11))
-                .foregroundStyle(Color(white: 0.45))
+                .foregroundStyle(palette.mutedText)
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -394,6 +415,7 @@ private struct EmptyQuotaRow: View {
 // MARK: - Tooltip panel
 
 private struct TooltipView: View {
+    @Environment(AppState.self) private var appState
     let title: String
     let tokenPercentText: String
     let tokenColor: Color
@@ -401,10 +423,12 @@ private struct TooltipView: View {
     let remainingText: String?
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         VStack(alignment: .leading, spacing: 5) {
             Text(title)
                 .font(.system(size: 11, weight: .semibold))
-                .foregroundStyle(.white)
+                .foregroundStyle(palette.primaryText)
 
             row(
                 dotColor: tokenColor,
@@ -419,26 +443,26 @@ private struct TooltipView: View {
             // have rather than collapsing the latter to "未知".
             if let elapsed = elapsedPercentText, let remaining = remainingText {
                 row(
-                    dotColor: Color(white: 0.55),
+                    dotColor: palette.tertiaryText,
                     label: "时间",
                     value: "已过去 \(elapsed) · 剩余 \(remaining)",
-                    valueColor: Color(white: 0.82),
+                    valueColor: palette.secondaryText,
                     valueWeight: .regular
                 )
             } else if let remaining = remainingText {
                 row(
-                    dotColor: Color(white: 0.55),
+                    dotColor: palette.tertiaryText,
                     label: "重置",
                     value: "剩余 \(remaining)",
-                    valueColor: Color(white: 0.82),
+                    valueColor: palette.secondaryText,
                     valueWeight: .regular
                 )
             } else {
                 row(
-                    dotColor: Color(white: 0.55),
+                    dotColor: palette.tertiaryText,
                     label: "时间",
                     value: "未知",
-                    valueColor: Color(white: 0.5),
+                    valueColor: palette.tertiaryText,
                     valueWeight: .regular
                 )
             }
@@ -446,12 +470,12 @@ private struct TooltipView: View {
         .font(.system(size: 11))
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
-        .background(Color.black)
+        .background(palette.tooltipBackground)
         // Same background-shape trick: rounded chrome without clipping.
         // (The tooltip itself doesn't host descendants that need to escape,
         // but staying consistent keeps the rendering simple.)
         .clipShape(RoundedRectangle(cornerRadius: 5))
-        .overlay(RoundedRectangle(cornerRadius: 5).stroke(Color(white: 0.22), lineWidth: 0.5))
+        .overlay(RoundedRectangle(cornerRadius: 5).stroke(palette.strongBorder, lineWidth: 0.5))
         .shadow(color: .black.opacity(0.5), radius: 5, y: 2)
     }
 
@@ -461,7 +485,7 @@ private struct TooltipView: View {
                 .fill(dotColor)
                 .frame(width: 6, height: 6)
             Text(label)
-                .foregroundStyle(Color(white: 0.55))
+                .foregroundStyle(appState.appTheme.palette.tertiaryText)
             Text(value)
                 .foregroundStyle(valueColor)
                 .fontWeight(valueWeight)
@@ -472,26 +496,29 @@ private struct TooltipView: View {
 // MARK: - Progress bar
 
 private struct ProgressBar: View {
+    @Environment(AppState.self) private var appState
     let value: Double
     var fill: Color? = nil
-    var background: Color = Color(white: 0.18)
+    var background: Color? = nil
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         GeometryReader { geo in
             ZStack(alignment: .leading) {
-                Capsule().fill(background)
+                Capsule().fill(background ?? palette.progressTrack)
                 Capsule()
-                    .fill(fill ?? Self.color(for: value))
+                    .fill(fill ?? Self.color(for: value, palette: palette))
                     .frame(width: geo.size.width * CGFloat(min(max(value, 0), 100) / 100))
             }
         }
     }
 
-    static func color(for utilization: Double) -> Color {
+    static func color(for utilization: Double, palette: ThemePalette) -> Color {
         switch utilization {
-        case ..<70:    return Color(white: 0.85)
-        case 70..<90:  return Color(red: 0.96, green: 0.62, blue: 0.04)
-        default:       return Color(red: 0.94, green: 0.27, blue: 0.27)
+        case ..<70:    return palette.success
+        case 70..<90:  return palette.warning
+        default:       return palette.danger
         }
     }
 }
@@ -499,6 +526,7 @@ private struct ProgressBar: View {
 // MARK: - Provider icon
 
 private struct ProviderIcon: View {
+    @Environment(AppState.self) private var appState
     let provider: ProviderRateLimit.Provider
 
     var body: some View {
@@ -510,7 +538,7 @@ private struct ProviderIcon: View {
         } else {
             Image(systemName: provider == .codex ? "terminal" : "sparkles")
                 .font(.system(size: 12))
-                .foregroundStyle(Color(white: 0.6))
+                .foregroundStyle(appState.appTheme.palette.secondaryText)
         }
     }
 

--- a/VibeUsage/Views/SettingsView.swift
+++ b/VibeUsage/Views/SettingsView.swift
@@ -1,5 +1,6 @@
 import SwiftUI
 import ServiceManagement
+import VibeUsageCore
 
 struct SettingsView: View {
     @Environment(AppState.self) private var appState
@@ -14,6 +15,8 @@ struct SettingsView: View {
     @State private var relinkTask: Task<Void, Never>?
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         Form {
             // Sync section
             Section {
@@ -22,7 +25,7 @@ struct SettingsView: View {
                         HStack(spacing: 8) {
                             Text(apiKeyDisplay)
                                 .font(.system(.body, design: .monospaced))
-                                .foregroundStyle(Color(white: 0.5))
+                                .foregroundStyle(palette.tertiaryText)
 
                             Button(isRelinking ? "等待确认…" : "重新链接") {
                                 relinkTask = Task { await relink() }
@@ -35,18 +38,18 @@ struct SettingsView: View {
                                     cancelRelink()
                                 }
                                 .font(.caption)
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(palette.secondaryText)
                             }
                         }
                         if let relinkUserCode {
                             Text("验证码: \(relinkUserCode)")
                                 .font(.system(.caption, design: .monospaced))
-                                .foregroundStyle(.secondary)
+                                .foregroundStyle(palette.secondaryText)
                         }
                         if let relinkError {
                             Text(relinkError)
                                 .font(.caption)
-                                .foregroundStyle(.red)
+                                .foregroundStyle(palette.danger)
                                 .lineLimit(2)
                         }
                     }
@@ -57,7 +60,7 @@ struct SettingsView: View {
                         switch appState.syncStatus {
                         case .idle:
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
+                                .foregroundStyle(palette.success)
                             Text("正常")
                         case .syncing:
                             ProgressView()
@@ -65,11 +68,11 @@ struct SettingsView: View {
                             Text("同步中...")
                         case .success:
                             Image(systemName: "checkmark.circle.fill")
-                                .foregroundStyle(.green)
+                                .foregroundStyle(palette.success)
                             Text("同步成功")
                         case .error(let msg):
                             Image(systemName: "exclamationmark.circle.fill")
-                                .foregroundStyle(.red)
+                                .foregroundStyle(palette.danger)
                             Text(msg)
                                 .lineLimit(1)
                         }
@@ -81,11 +84,28 @@ struct SettingsView: View {
                     LabeledContent("上次同步") {
                         Text(Formatters.formatRelativeTime(lastSync))
                             .font(.caption)
-                            .foregroundStyle(.secondary)
+                            .foregroundStyle(palette.secondaryText)
                     }
                 }
             } header: {
                 Text("同步")
+            }
+
+            Section {
+                Picker("主题", selection: Binding(
+                    get: { appState.appTheme },
+                    set: { appState.appTheme = $0 }
+                )) {
+                    ForEach(AppTheme.allCases) { theme in
+                        Text(theme.displayName).tag(theme)
+                    }
+                }
+                .pickerStyle(.menu)
+            } header: {
+                Text("外观")
+            } footer: {
+                Text("主题会立即应用到弹窗和设置窗口")
+                    .font(.caption)
             }
 
             // Menu bar display
@@ -94,12 +114,12 @@ struct SettingsView: View {
                     get: { appState.showCostInMenuBar },
                     set: { appState.showCostInMenuBar = $0 }
                 ))
-                .tint(.green)
+                .tint(palette.accent)
                 Toggle("菜单栏显示 Token", isOn: Binding(
                     get: { appState.showTokensInMenuBar },
                     set: { appState.showTokensInMenuBar = $0 }
                 ))
-                .tint(.green)
+                .tint(palette.accent)
             } header: {
                 Text("菜单栏")
             } footer: {
@@ -110,7 +130,7 @@ struct SettingsView: View {
             // Auto-start + general
             Section {
                 Toggle("开机自启动", isOn: $autoStartEnabled)
-                    .tint(.green)
+                    .tint(palette.accent)
                     .onChange(of: autoStartEnabled) { _, newValue in
                         setAutoStart(newValue)
                     }
@@ -123,7 +143,7 @@ struct SettingsView: View {
                 LabeledContent("版本") {
                     Text(Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? AppConfig.version)
                         .font(.caption)
-                        .foregroundStyle(.secondary)
+                        .foregroundStyle(palette.secondaryText)
                 }
 
                 Button("检查更新") {
@@ -152,7 +172,12 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 420, height: 420)
+        .scrollContentBackground(.hidden)
+        .background(palette.windowBackground)
+        .foregroundStyle(palette.primaryText)
+        .tint(palette.accent)
+        .preferredColorScheme(appState.appTheme.colorScheme)
+        .frame(width: 420, height: 480)
         .onAppear {
             loadSettings()
         }

--- a/VibeUsage/Views/SummaryCardsView.swift
+++ b/VibeUsage/Views/SummaryCardsView.swift
@@ -37,20 +37,23 @@ struct SummaryCardsView: View {
     }
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         HStack(alignment: .top, spacing: 8) {
-            StatCard(label: "预估费用", value: Formatters.formatCost(totalCost), color: Color(red: 0.2, green: 0.8, blue: 0.5))
+            StatCard(label: "预估费用", value: Formatters.formatCost(totalCost), color: palette.accent)
             StatCard(label: "输入+输出 Token", value: Formatters.formatNumber(totalTokens))
             StatCard(label: "缓存 Token", value: Formatters.formatNumber(totalCachedInputTokens))
-            StatCard(label: "活跃时长", value: Formatters.formatDuration(totalActiveSeconds), color: Color(red: 0.38, green: 0.6, blue: 1.0))
+            StatCard(label: "活跃时长", value: Formatters.formatDuration(totalActiveSeconds), color: palette.secondaryAccent)
         }
         .fixedSize(horizontal: false, vertical: true)
     }
 }
 
 private struct StatCard: View {
+    @Environment(AppState.self) private var appState
     let label: String
     let value: String
-    var color: Color = .white
+    var color: Color?
 
     // Reserve fixed line-box heights so all cards render at exactly the same height,
     // even when minimumScaleFactor shrinks the value glyphs in narrower columns.
@@ -58,16 +61,18 @@ private struct StatCard: View {
     private let valueHeight: CGFloat = 24   // 20pt font
 
     var body: some View {
+        let palette = appState.appTheme.palette
+
         VStack(alignment: .leading, spacing: 6) {
             Text(label)
                 .font(.system(size: 12))
-                .foregroundStyle(Color(white: 0.63))
+                .foregroundStyle(palette.secondaryText)
                 .lineLimit(1)
                 .minimumScaleFactor(0.85)
                 .frame(height: labelHeight, alignment: .leading)
             Text(value)
                 .font(.system(size: 20, weight: .bold, design: .monospaced))
-                .foregroundStyle(color)
+                .foregroundStyle(color ?? palette.primaryText)
                 .lineLimit(1)
                 .minimumScaleFactor(0.6)
                 .frame(height: valueHeight, alignment: .leading)
@@ -75,11 +80,11 @@ private struct StatCard: View {
         .frame(maxWidth: .infinity, alignment: .leading)
         .padding(.horizontal, 11)
         .padding(.vertical, 13)
-        .background(Color(white: 0.09))
+        .background(palette.card)
         .cornerRadius(4)
         .overlay(
             RoundedRectangle(cornerRadius: 4)
-                .stroke(Color(white: 0.16), lineWidth: 1)
+                .stroke(palette.border, lineWidth: 1)
         )
     }
 }

--- a/VibeUsageCore/AppTheme.swift
+++ b/VibeUsageCore/AppTheme.swift
@@ -1,0 +1,36 @@
+import Foundation
+
+public enum AppTheme: String, CaseIterable, Identifiable {
+    case dark
+    case light
+    case grass
+    case gold
+
+    public static let userDefaultsKey = "appTheme"
+
+    public var id: String { rawValue }
+
+    public var displayName: String {
+        switch self {
+        case .dark: return "暗黑"
+        case .light: return "浅色"
+        case .grass: return "青草"
+        case .gold: return "金色"
+        }
+    }
+
+    public static func storedValue(_ rawValue: String?) -> AppTheme {
+        guard let rawValue, let theme = AppTheme(rawValue: rawValue) else {
+            return .dark
+        }
+        return theme
+    }
+
+    public static func load(from defaults: UserDefaults = .standard) -> AppTheme {
+        storedValue(defaults.string(forKey: userDefaultsKey))
+    }
+
+    public func save(to defaults: UserDefaults = .standard) {
+        defaults.set(rawValue, forKey: Self.userDefaultsKey)
+    }
+}


### PR DESCRIPTION
## Summary
- Add four persisted app themes: dark, light, grass, and gold.
- Add an Appearance theme picker in Settings.
- Route popover, settings, dashboard cards, filters, charts, and quota cards through a shared theme palette.

## Test Plan
- swift run ThemeChecks
- swift build
- ./scripts/build-app.sh
- codesign --verify --deep --strict "dist/Vibe Usage.app"
