### PR TITLE
docs: mention CraftAgent usage support

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,8 +116,9 @@ SwiftUI keeps delivering hover updates as the content slides under the cursor.
 1. `SyncScheduler` fires every 30 minutes (background upload + fetch)
 2. `SyncEngine` runs the `@vibe-cafe/vibe-usage` CLI via `CLIBridge`
 3. `RuntimeDetector` finds Node.js or Bun on the system
-4. After sync completes, `fetchUsageData()` refreshes the dashboard
-5. Opening the popover calls `fetchUsageDataIfNeeded()` (60s debounce) — fetch only, no upload
+4. The CLI owns local tool parsing (including CraftAgent usage via `craft-agent` source); the app only displays server-returned buckets
+5. After sync completes, `fetchUsageData()` refreshes the dashboard
+6. Opening the popover calls `fetchUsageDataIfNeeded()` (60s debounce) — fetch only, no upload
 
 ### Rate-Limit Refresh
 No background timer. `RateLimitCoordinator` is driven entirely by user-visible events:

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ macOS 菜单栏应用，自动追踪 AI 编程工具的 Token 用量和费用。
 
 - 菜单栏常驻，后台每 5 分钟自动同步数据
 - 弹出窗口查看费用、Token 用量、趋势图表
+- **用量统计**：通过 [@vibe-cafe/vibe-usage](https://github.com/vibe-cafe/vibe-usage) 同步 Claude Code / Codex CLI / CraftAgent 等工具的 Token 使用数据
 - **订阅配额监控**：本地读取 Codex / Claude 的 5 小时 / 7 天 token 配额，悬停查看消耗 vs 时间对比
 - 支持按日期 / 终端 / 工具 / 模型 / 项目筛选
 - 可在菜单栏显示今日费用和 Token 数


### PR DESCRIPTION
## Summary

- document that the app can display CraftAgent usage once the CLI sync source is available
- clarify that local tool parsing remains owned by `@vibe-cafe/vibe-usage`, while the app displays server-returned buckets

## Dependency

Depends on vibe-cafe/vibe-usage#24 adding the `craft-agent` parser/source.

## Test

```bash
git diff --check
```

I also attempted `swift build`, but dependency fetching for Sparkle did not complete before the local timeout. This PR only changes README/AGENTS documentation.