### PR TITLE
feat: add provider-specific rate limit toggles

### DIFF
--- a/VibeUsage/Models/AppState.swift
+++ b/VibeUsage/Models/AppState.swift
@@ -157,6 +157,9 @@ final class AppState {
     var runtimeAvailable: Bool = true
 
     // MARK: - Rate Limits (subscription quota for Claude + Codex)
+    var codexRateLimitEnabled: Bool = true {
+        didSet { UserDefaults.standard.set(codexRateLimitEnabled, forKey: "codexRateLimitEnabled") }
+    }
     var rateLimits: [ProviderRateLimit] = []
 
     /// Enabling Claude rate-limit monitoring installs a wrapper into Claude
@@ -216,11 +219,17 @@ final class AppState {
         self.showCostInMenuBar = UserDefaults.standard.object(forKey: "showCostInMenuBar") as? Bool ?? true
         self.showTokensInMenuBar = UserDefaults.standard.object(forKey: "showTokensInMenuBar") as? Bool ?? false
         self.showInDock = UserDefaults.standard.object(forKey: "showInDock") as? Bool ?? true
+        let legacyRateLimitEnabled = UserDefaults.standard.object(forKey: "rateLimitMonitoringEnabled") as? Bool
+        self.codexRateLimitEnabled = UserDefaults.standard.object(forKey: "codexRateLimitEnabled") as? Bool ?? legacyRateLimitEnabled ?? true
         self.claudeRateLimitEnabled = UserDefaults.standard.bool(forKey: "claudeRateLimitEnabled")
 
-        // Self-heal: if capture was enabled but a claude-hud upgrade or
-        // `/statusline` clobbered our wrapper, silently re-assert it.
-        StatuslineHook.verifyAndRepair(enabled: claudeRateLimitEnabled)
+        // Self-heal only while Claude monitoring is enabled. When disabled,
+        // restore Claude Code's statusline command and keep that provider idle.
+        if claudeRateLimitEnabled {
+            StatuslineHook.verifyAndRepair(enabled: true)
+        } else {
+            _ = StatuslineHook.uninstall()
+        }
 
         let loadedConfig = ConfigManager.load()
         self.config = loadedConfig
@@ -234,8 +243,10 @@ final class AppState {
         }
 
         // Rate limits are independent of configuration — both Codex and Claude
-        // read local files (no auth). Start regardless.
-        startRateLimitCoordinator()
+        // read local files (no auth). Start only for enabled providers.
+        if codexRateLimitEnabled || claudeRateLimitEnabled {
+            startRateLimitCoordinator()
+        }
     }
 
     /// Save config to disk and start scheduler.
@@ -315,9 +326,40 @@ final class AppState {
         await fetchUsageData()
     }
 
+    /// Toggle Codex quota monitoring. Codex is read-only, so disabling just
+    /// stops scans and hides its snapshot.
+    func setCodexRateLimitEnabled(_ enabled: Bool) async {
+        guard codexRateLimitEnabled != enabled else { return }
+        codexRateLimitEnabled = enabled
+
+        if enabled {
+            if rateLimitCoordinator == nil { startRateLimitCoordinator() }
+            await refreshCodexRateLimit()
+        } else {
+            removeRateLimit(for: .codex)
+        }
+    }
+
+    /// Toggle Claude quota monitoring. Disabling restores Claude Code's
+    /// statusline command and hides its snapshot.
+    func setClaudeRateLimitEnabled(_ enabled: Bool) async {
+        guard claudeRateLimitEnabled != enabled else { return }
+        claudeRateLimitInstallError = nil
+
+        if enabled {
+            if rateLimitCoordinator == nil { startRateLimitCoordinator() }
+            await enableClaudeRateLimit()
+        } else {
+            claudeRateLimitEnabled = false
+            removeRateLimit(for: .claudeCode)
+            _ = StatuslineHook.uninstall()
+        }
+    }
+
     /// Refresh Codex rate limits unconditionally. Safe — no keychain prompts.
     /// Used by the manual "更新数据" / retry paths.
     func refreshCodexRateLimit() async {
+        guard codexRateLimitEnabled else { return }
         await rateLimitCoordinator?.refreshCodex()
     }
 
@@ -325,12 +367,14 @@ final class AppState {
     /// Used by popover-open so toggling the menu bar doesn't re-walk the
     /// Codex session tree on every click.
     func refreshCodexRateLimitIfNeeded() async {
+        guard codexRateLimitEnabled else { return }
         await rateLimitCoordinator?.refreshCodexIfNeeded()
     }
 
     /// Refresh Claude rate limits on popover-open (debounced). Cheap local-file
     /// read now — safe to fire automatically, no prompts.
     func refreshClaudeRateLimitIfNeeded() async {
+        guard claudeRateLimitEnabled else { return }
         await rateLimitCoordinator?.refreshClaudeIfNeeded()
     }
 
@@ -383,6 +427,10 @@ final class AppState {
     var claudeRateLimitInstallError: String?
 
     // MARK: - Private
+
+    private func removeRateLimit(for provider: ProviderRateLimit.Provider) {
+        rateLimits.removeAll { $0.provider == provider }
+    }
 
     private func startRateLimitCoordinator() {
         let coord = RateLimitCoordinator(appState: self)

--- a/VibeUsage/Services/RateLimitCoordinator.swift
+++ b/VibeUsage/Services/RateLimitCoordinator.swift
@@ -20,6 +20,7 @@ final class RateLimitCoordinator {
     /// Used by the manual "更新数据" path; popover-open should prefer the
     /// debounced `refreshCodexIfNeeded` to avoid repeat work on rapid open/close.
     func refreshCodex() async {
+        guard appState?.codexRateLimitEnabled == true else { return }
         let codex = await Task.detached(priority: .userInitiated) {
             CodexRateLimitReader.read()
         }.value
@@ -38,15 +39,10 @@ final class RateLimitCoordinator {
     }
 
     /// Refresh Claude from the local statusline-capture file. Auth-free and
-    /// cheap. If the user hasn't enabled capture yet, surface the disabled
-    /// placeholder (the card's "启用" button installs the hook).
+    /// cheap; only runs while Claude monitoring is enabled.
     func refreshClaude() async {
-        let enabled = appState?.claudeRateLimitEnabled == true
-        debugLog("[rate-limit] refreshClaude() entered, enabled=\(enabled)")
-        guard enabled else {
-            upsert(ProviderRateLimit(provider: .claudeCode, status: .disabled, fetchedAt: nil))
-            return
-        }
+        guard appState?.claudeRateLimitEnabled == true else { return }
+        debugLog("[rate-limit] refreshClaude() entered")
         let snapshot = await Task.detached(priority: .userInitiated) {
             ClaudeRateLimitReader.read()
         }.value
@@ -73,10 +69,12 @@ final class RateLimitCoordinator {
     /// Ensure both providers have at least a placeholder entry so the UI renders
     /// the disabled / enable affordance for Claude on first launch.
     func seedPlaceholders() {
-        if appState?.rateLimits.contains(where: { $0.provider == .codex }) != true {
+        if appState?.codexRateLimitEnabled == true,
+           appState?.rateLimits.contains(where: { $0.provider == .codex }) != true {
             upsert(ProviderRateLimit(provider: .codex, status: .noData, fetchedAt: nil))
         }
-        if appState?.rateLimits.contains(where: { $0.provider == .claudeCode }) != true {
+        if appState?.claudeRateLimitEnabled == true,
+           appState?.rateLimits.contains(where: { $0.provider == .claudeCode }) != true {
             upsert(ProviderRateLimit(provider: .claudeCode, status: .disabled, fetchedAt: nil))
         }
     }

--- a/VibeUsage/Services/StatuslineHook.swift
+++ b/VibeUsage/Services/StatuslineHook.swift
@@ -105,14 +105,18 @@ enum StatuslineHook {
     static func uninstall() -> Result<Void, HookError> {
         do {
             var settings = try loadSettings()
-            if let original = try? String(contentsOf: sidecarURL, encoding: .utf8),
-               !original.isEmpty {
-                settings["statusLine"] = ["type": "command", "command": original]
-            } else {
-                settings.removeValue(forKey: "statusLine")
+            let current = (settings["statusLine"] as? [String: Any])?["command"] as? String
+            if current == wrapperCommand {
+                if let original = try? String(contentsOf: sidecarURL, encoding: .utf8),
+                   !original.isEmpty {
+                    settings["statusLine"] = ["type": "command", "command": original]
+                } else {
+                    settings.removeValue(forKey: "statusLine")
+                }
+                try saveSettings(settings)
             }
-            try saveSettings(settings)
-            debugLog("[statusline] wrapper uninstalled, original restored")
+            removeGeneratedFiles()
+            debugLog("[statusline] wrapper uninstalled")
             return .success(())
         } catch let e as HookError {
             return .failure(e)
@@ -176,6 +180,12 @@ enum StatuslineHook {
               FileManager.default.fileExists(atPath: settingsURL.path) else { return }
         try? FileManager.default.copyItem(at: settingsURL, to: backupURL)
         debugLog("[statusline] backed up settings.json -> \(backupURL.path)")
+    }
+
+    private static func removeGeneratedFiles() {
+        for url in [wrapperURL, sidecarURL, rateLimitFileURL, backupURL] {
+            try? FileManager.default.removeItem(at: url)
+        }
     }
 
     private static func writeWrapperScript() throws {

--- a/VibeUsage/Views/PopoverView.swift
+++ b/VibeUsage/Views/PopoverView.swift
@@ -216,14 +216,10 @@ struct PopoverView: View {
             ScrollView(.vertical, showsIndicators: false) {
                 VStack(alignment: .leading, spacing: 14) {
                     if appState.isInitialDataLoad || (!appState.hasLoadedUsageData && appState.buckets.isEmpty) {
-                        RateLimitCardView()
-                            .zIndex(1)
-                        Divider()
-                            .background(Color(white: 0.16))
-                            .padding(.vertical, 2)
+                        rateLimitSection
                         loadingDashboardView
                     } else if !appState.hasAnyData {
-                        RateLimitCardView()
+                        rateLimitSection
                         emptyStateView
                     } else {
                         dashboardContent
@@ -249,11 +245,7 @@ struct PopoverView: View {
             VStack(alignment: .leading, spacing: 14) {
                 // Rate-limit row gets its own block separated from the usage
                 // dashboard by a divider so quota and consumption stats stay distinct.
-                RateLimitCardView()
-                    .zIndex(1)
-                Divider()
-                    .background(Color(white: 0.16))
-                    .padding(.vertical, 2)
+                rateLimitSection
                 FilterTagsView()
                     .zIndex(10)
                 SummaryCardsView()
@@ -270,6 +262,17 @@ struct PopoverView: View {
             }
         }
         .animation(.easeInOut(duration: 0.2), value: appState.isRefreshingData)
+    }
+
+    @ViewBuilder
+    private var rateLimitSection: some View {
+        if appState.codexRateLimitEnabled || appState.claudeRateLimitEnabled {
+            RateLimitCardView()
+                .zIndex(1)
+            Divider()
+                .background(Color(white: 0.16))
+                .padding(.vertical, 2)
+        }
     }
 
     // MARK: - Header

--- a/VibeUsage/Views/RateLimitCardView.swift
+++ b/VibeUsage/Views/RateLimitCardView.swift
@@ -25,8 +25,10 @@ struct RateLimitCardView: View {
             ProviderCard(snapshot: codex)
         } else if showClaude {
             ProviderCard(snapshot: claude)
-        } else {
+        } else if appState.codexRateLimitEnabled || appState.claudeRateLimitEnabled {
             noticeBar
+        } else {
+            EmptyView()
         }
     }
 
@@ -40,7 +42,14 @@ struct RateLimitCardView: View {
     /// actionable affordance and stay visible. When BOTH sides are `.noData`,
     /// `body` swaps the row for `noticeBar` so the empty state is whisper-quiet.
     private func shouldShowCard(_ snap: ProviderRateLimit) -> Bool {
-        snap.status != .noData
+        switch snap.provider {
+        case .codex where !appState.codexRateLimitEnabled:
+            return false
+        case .claudeCode where !appState.claudeRateLimitEnabled:
+            return false
+        default:
+            return snap.status != .noData
+        }
     }
 
     /// Single-line whisper shown when neither Codex nor Claude has any data.

--- a/VibeUsage/Views/SettingsView.swift
+++ b/VibeUsage/Views/SettingsView.swift
@@ -88,6 +88,27 @@ struct SettingsView: View {
                 Text("同步")
             }
 
+            // Subscription quota monitoring
+            Section {
+                Toggle("Codex 订阅配额监控", isOn: Binding(
+                    get: { appState.codexRateLimitEnabled },
+                    set: { newValue in
+                        Task { await appState.setCodexRateLimitEnabled(newValue) }
+                    }
+                ))
+                .tint(.green)
+
+                Toggle("Claude Code 订阅配额监控", isOn: Binding(
+                    get: { appState.claudeRateLimitEnabled },
+                    set: { newValue in
+                        Task { await appState.setClaudeRateLimitEnabled(newValue) }
+                    }
+                ))
+                .tint(.green)
+            } header: {
+                Text("订阅配额")
+            }
+
             // Menu bar display
             Section {
                 Toggle("菜单栏显示费用", isOn: Binding(
@@ -161,7 +182,7 @@ struct SettingsView: View {
             }
         }
         .formStyle(.grouped)
-        .frame(width: 420, height: 420)
+        .frame(width: 420, height: 460)
         .onAppear {
             loadSettings()
         }


### PR DESCRIPTION
Close #20 

## Summary

- Add separate settings toggles for Codex and Claude Code subscription quota monitoring
- Stop Codex quota scanning independently when Codex monitoring is disabled
- Restore Claude Code statusline configuration when Claude monitoring is disabled
- Hide the quota section entirely when both providers are disabled
- Remove the explanatory footer text from the settings quota section

## Implementation Notes

- Codex monitoring remains read-only and only scans local session files.
- Claude Code monitoring still installs the statusline capture hook when enabled and uninstalls it when disabled.
- The quota card no longer shows a disabled placeholder when both provider toggles are off.

## Test

- `swift build`

## Display

### Close claude code monitor

<img width="936" height="636" alt="image" src="https://github.com/user-attachments/assets/54e161ab-42ce-4e11-a9e0-13c4799adfc0" />

### Open claude code monitor
<img width="940" height="634" alt="image" src="https://github.com/user-attachments/assets/c4cb832f-cd5e-4348-bffd-5ba11b397280" />
