### PR TITLE
feat(rate-limit): API-backed Codex/Claude quota — tiers, reset credits & smoother loading

### DIFF
--- a/Tests/VibeUsageTests/ClaudeRateLimitReaderTests.swift
+++ b/Tests/VibeUsageTests/ClaudeRateLimitReaderTests.swift
@@ -1,0 +1,35 @@
+import Foundation
+import Testing
+@testable import VibeUsage
+
+struct ClaudeRateLimitReaderTests {
+    @Test
+    func mapsMaxTiersToDistinctBadges() {
+        #expect(ClaudeRateLimitReader.formatTier("default_claude_max_20x") == "Max 20x")
+        #expect(ClaudeRateLimitReader.formatTier("default_claude_max_5x") == "Max 5x")
+        // A bare "max" with no multiplier still resolves to the base badge.
+        #expect(ClaudeRateLimitReader.formatTier("default_claude_max") == "Max")
+    }
+
+    @Test
+    func mapsNonMaxTiers() {
+        #expect(ClaudeRateLimitReader.formatTier("default_claude_pro") == "Pro")
+        #expect(ClaudeRateLimitReader.formatTier("claude_team") == "Team")
+        #expect(ClaudeRateLimitReader.formatTier("free") == "Free")
+    }
+
+    @Test
+    func suppressesApiAndEmptyTiers() {
+        // API-key users carry no meaningful subscription badge.
+        #expect(ClaudeRateLimitReader.formatTier("api") == nil)
+        #expect(ClaudeRateLimitReader.formatTier("") == nil)
+        #expect(ClaudeRateLimitReader.formatTier(nil) == nil)
+    }
+
+    @Test
+    func titleCasesUnknownTiers() {
+        // A future/unrecognized tier still surfaces something readable rather
+        // than silently vanishing.
+        #expect(ClaudeRateLimitReader.formatTier("default_claude_ultra") == "Ultra")
+    }
+}

--- a/Tests/VibeUsageTests/CodexRateLimitReaderTests.swift
+++ b/Tests/VibeUsageTests/CodexRateLimitReaderTests.swift
@@ -59,6 +59,112 @@ struct CodexRateLimitReaderTests {
 
         #expect(snapshot.fiveHour?.utilization == 84)
     }
+
+    /// Production `sessionsDir` is the top-level `~/.codex/sessions` folder,
+    /// with rollouts nested under `yyyy/MM/dd`. This exercises the bounded
+    /// fast path directly (as opposed to the other tests, which hand a leaf
+    /// day-directory straight to `read` and exercise the full-scan fallback).
+    @Test
+    func findsRolloutInTodaysDateFolderViaFastPath() throws {
+        let now = try #require(parseFixtureDate("2026-07-10T04:00:00Z"))
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexRateLimitReaderTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        try DatedRollout.write(
+            under: root,
+            day: now,
+            named: "rollout-today.jsonl",
+            eventTimestamp: "2026-07-10T03:44:06Z",
+            primaryUsed: 42,
+            modifiedAt: now
+        )
+
+        let snapshot = CodexRateLimitReader.read(sessionsDir: root, now: now)
+
+        #expect(snapshot.status == .ok)
+        #expect(snapshot.fiveHour?.utilization == 42)
+    }
+
+    /// A rollout outside the lookback window can never carry a live window
+    /// (its 7-day slot would already be expired), so the bounded fast path
+    /// must not fall back to scanning it just because today's folder happens
+    /// to be empty.
+    @Test
+    func ignoresRolloutsOlderThanTheLookbackWindow() throws {
+        let now = try #require(parseFixtureDate("2026-07-10T04:00:00Z"))
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("CodexRateLimitReaderTests-\(UUID().uuidString)")
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        // Today's folder exists (so the fast path engages) but is empty.
+        try FileManager.default.createDirectory(
+            at: root.appendingPathComponent(DatedRollout.dayPath(for: now)),
+            withIntermediateDirectories: true
+        )
+
+        let staleDay = try #require(Calendar.current.date(byAdding: .day, value: -15, to: now))
+        try DatedRollout.write(
+            under: root,
+            day: staleDay,
+            named: "rollout-stale.jsonl",
+            eventTimestamp: "2026-06-25T03:44:06Z",
+            primaryUsed: 77,
+            modifiedAt: staleDay
+        )
+
+        let snapshot = CodexRateLimitReader.read(sessionsDir: root, now: now)
+
+        #expect(snapshot.status == .noData)
+    }
+}
+
+private enum DatedRollout {
+    static func dayPath(for day: Date) -> String {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy/MM/dd"
+        formatter.calendar = Calendar.current
+        formatter.timeZone = .current
+        return formatter.string(from: day)
+    }
+
+    static func write(
+        under root: URL,
+        day: Date,
+        named name: String,
+        eventTimestamp: String,
+        primaryUsed: Double,
+        modifiedAt: Date
+    ) throws {
+        let dayDir = root.appendingPathComponent(dayPath(for: day), isDirectory: true)
+        try FileManager.default.createDirectory(at: dayDir, withIntermediateDirectories: true)
+
+        let event: [String: Any] = [
+            "timestamp": eventTimestamp,
+            "type": "event_msg",
+            "payload": [
+                "type": "token_count",
+                "info": NSNull(),
+                "rate_limits": [
+                    "plan_type": "prolite",
+                    "primary": [
+                        "used_percent": primaryUsed,
+                        "window_minutes": 300,
+                        "resets_at": 4_102_444_800
+                    ],
+                    "secondary": [
+                        "used_percent": 13.0,
+                        "window_minutes": 10_080,
+                        "resets_at": 4_102_444_800
+                    ]
+                ]
+            ]
+        ]
+        let data = try JSONSerialization.data(withJSONObject: event, options: [.sortedKeys])
+        let file = dayDir.appendingPathComponent(name)
+        try (data + Data([0x0A])).write(to: file)
+        try FileManager.default.setAttributes([.modificationDate: modifiedAt], ofItemAtPath: file.path)
+    }
 }
 
 private struct SessionFixture {

--- a/VibeUsage/Models/AppConfig.swift
+++ b/VibeUsage/Models/AppConfig.swift
@@ -4,7 +4,11 @@ enum AppConfig {
     static let version = "0.5.3"
 
     #if DEBUG
-    static let defaultApiUrl = "http://localhost:3000"
+    /// DEBUG-only override so a dev build can be pointed at a real backend
+    /// (e.g. `VIBE_USAGE_API_URL=https://vibecafe.ai`) for end-to-end login
+    /// testing without hardcoding — falls back to the local dev server when
+    /// unset. Has no effect on release builds.
+    static let defaultApiUrl = ProcessInfo.processInfo.environment["VIBE_USAGE_API_URL"] ?? "http://localhost:3000"
     static let configFileName = "config.dev.json"
     static let isDev = true
     #else

--- a/VibeUsage/Models/RateLimit.swift
+++ b/VibeUsage/Models/RateLimit.swift
@@ -25,6 +25,7 @@ struct ProviderRateLimit: Equatable, Identifiable {
     }
 
     enum Status: Equatable {
+        case loading                   // first read is in flight; no prior snapshot to show yet
         case ok
         case noData                    // provider isn't installed or has no recent activity
         case disabled                  // user hasn't opted into this provider's monitoring yet
@@ -40,6 +41,16 @@ struct ProviderRateLimit: Equatable, Identifiable {
     var sevenDaySonnet: RateLimitWindow?   // Claude Max plan only
     var extraUsage: ExtraUsage?
     var planLabel: String?                 // e.g. "free", "Plus", "Pro", "Max"
+    /// Number of unused manual rate-limit "reset" credits on the account
+    /// (Codex only). Each credit lets the user reset one usage window early.
+    /// nil = unknown / not applicable (free plan, API-key session, or the
+    /// local-file fallback which can't see this server-side value).
+    var resetCredits: Int?
     var status: Status
     var fetchedAt: Date?
+    /// True while a refresh is in flight. Independent of `status` so a
+    /// background refresh (popover reopened, manual "更新数据") can keep the
+    /// last-known numbers on screen instead of yanking them out for a spinner —
+    /// only a *first-ever* read (no prior snapshot) uses `.loading` for that.
+    var isFetching: Bool = false
 }

--- a/VibeUsage/Services/ClaudeRateLimitReader.swift
+++ b/VibeUsage/Services/ClaudeRateLimitReader.swift
@@ -31,6 +31,21 @@ enum ClaudeRateLimitReader {
     private static let stalenessThreshold: TimeInterval = 30 * 60
 
     static func read() -> ProviderRateLimit {
+        // The subscription tier lives in ~/.claude.json (see `readSubscriptionTier`),
+        // a different local file than the rate-limit capture. It's available as
+        // soon as the user has logged into Claude Code — even before the
+        // statusline hook has captured any usage — so inject it into whatever
+        // window snapshot we produce below, across all statuses (.ok when we
+        // have data, but also .disabled / .noData so the plan badge shows on
+        // the "enable" card too). Auth-free plain-file read; no keychain.
+        var result = readWindows()
+        if result.planLabel == nil {
+            result.planLabel = readSubscriptionTier()
+        }
+        return result
+    }
+
+    private static func readWindows() -> ProviderRateLimit {
         let url = StatuslineHook.rateLimitFileURL
         debugLog("[rate-limit] ClaudeRateLimitReader.read() -> \(url.path)")
 
@@ -78,6 +93,78 @@ enum ClaudeRateLimitReader {
             status: .ok,
             fetchedAt: Date()
         )
+    }
+
+    // MARK: - Subscription tier
+
+    /// Read the user's Claude subscription tier from `~/.claude.json` — the
+    /// only auth-free local source for it. The statusline payload carries no
+    /// plan field (a present `rate_limits` block only tells us "some paid
+    /// plan"), and claude-hud's approach reads the OAuth token out of the macOS
+    /// Keychain, which would pop a system authorization prompt on first access
+    /// — exactly the friction we're required to avoid. `~/.claude.json` is a
+    /// plain 0644 config file Claude Code writes on login; its
+    /// `oauthAccount.*RateLimitTier` carries a value like
+    /// `"default_claude_max_5x"`, which uniquely distinguishes Max 5x / Max 20x
+    /// / Pro — finer-grained than the Keychain's `subscriptionType` ("max").
+    ///
+    /// Returns nil (→ no plan badge) whenever the file is absent/unparseable or
+    /// the tier is an API/unknown value; we never surface a wrong label.
+    private static func readSubscriptionTier() -> String? {
+        for url in claudeConfigCandidates() {
+            guard let data = try? Data(contentsOf: url),
+                  let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                  let account = obj["oauthAccount"] as? [String: Any] else { continue }
+            // Prefer the user-scoped tier; fall back to the org-scoped one
+            // (personal Max plans populate `organizationRateLimitTier`).
+            let raw = (account["userRateLimitTier"] as? String)
+                ?? (account["organizationRateLimitTier"] as? String)
+            if let label = formatTier(raw) { return label }
+        }
+        return nil
+    }
+
+    /// Candidate paths for Claude Code's global config. `~/.claude.json` is the
+    /// default; when the user relocates their config via `CLAUDE_CONFIG_DIR`,
+    /// Claude Code writes `.claude.json` inside that directory instead, so try
+    /// it first.
+    private static func claudeConfigCandidates() -> [URL] {
+        let home = FileManager.default.homeDirectoryForCurrentUser
+        var urls: [URL] = []
+        if let custom = ProcessInfo.processInfo.environment["CLAUDE_CONFIG_DIR"],
+           !custom.isEmpty {
+            let base = URL(fileURLWithPath: (custom as NSString).expandingTildeInPath)
+            urls.append(base.appendingPathComponent(".claude.json"))
+        }
+        urls.append(home.appendingPathComponent(".claude.json"))
+        return urls
+    }
+
+    /// Map a raw rate-limit-tier string (e.g. `"default_claude_max_20x"`) to a
+    /// customer-facing badge. Substring matching keeps us resilient to the
+    /// `default_claude_` prefix drifting across Claude Code versions.
+    static func formatTier(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        let l = raw.lowercased()
+        if l.contains("max") {
+            if l.contains("20x") { return "Max 20x" }
+            if l.contains("5x") { return "Max 5x" }
+            return "Max"
+        }
+        if l.contains("pro") { return "Pro" }
+        if l.contains("team") { return "Team" }
+        if l.contains("enterprise") { return "Enterprise" }
+        if l.contains("free") { return "Free" }
+        // API-key users carry no meaningful subscription badge.
+        if l.contains("api") { return nil }
+        // Unknown tier: strip the known prefix and title-case what remains so a
+        // new plan still shows *something* recognizable rather than nothing.
+        let cleaned = l
+            .replacingOccurrences(of: "default_claude_", with: "")
+            .replacingOccurrences(of: "_", with: " ")
+            .trimmingCharacters(in: .whitespaces)
+        guard !cleaned.isEmpty else { return nil }
+        return cleaned.prefix(1).uppercased() + cleaned.dropFirst()
     }
 
     // MARK: - Parsing

--- a/VibeUsage/Services/CodexRateLimitReader.swift
+++ b/VibeUsage/Services/CodexRateLimitReader.swift
@@ -62,22 +62,92 @@ enum CodexRateLimitReader {
         var modifiedAt: Date?
     }
 
+    /// How many calendar days back to look for rollout files. A `rate_limits`
+    /// event older than the 7-day window is provably expired — `parseWindow`
+    /// already discards any slot whose `resets_at` has passed — so nothing
+    /// beyond that horizon can ever contribute a *live* window. The extra two
+    /// days absorb a session that straddles a day boundary (its rollout file
+    /// lives in the day it was *created*, but keeps getting appended to) and
+    /// any local clock/timezone drift between when Codex wrote the folder and
+    /// when we compute "today" here.
+    private static let lookbackDays = 9
+
     /// Find the newest rate-limit event globally, not merely the event in the
     /// most recently-created rollout file. Codex Desktop can keep an older main
     /// session active after creating a newer guardian/sub-agent rollout, so a
     /// filename-first walk can pin the UI to the guardian's older snapshot.
     ///
-    /// Files are ordered by modification time for efficiency. Once the next
-    /// file's mtime is no newer than the best event timestamp, it cannot contain
-    /// a later append and the remaining files can be skipped safely.
+    /// Codex lays sessions out as `sessions/yyyy/MM/dd/rollout-*.jsonl`, so the
+    /// fast path only touches the last `lookbackDays` day-folders instead of
+    /// walking a user's entire multi-year session history on every refresh —
+    /// that full walk was the main source of a sluggish first popover-open for
+    /// long-time users. If `sessionsDir` doesn't follow that layout (test
+    /// fixtures hand us a leaf directory directly, and a future Codex version
+    /// might restructure), fall back to the old full recursive walk so we
+    /// never silently miss data.
     private static func scanForLatest(in sessionsDir: URL, now: Date) -> Snapshot? {
+        let dayDirs = recentDayDirectories(under: sessionsDir, now: now)
+        if !dayDirs.isEmpty {
+            return scan(files: dayDirs.flatMap(rolloutFiles(in:)), now: now)
+        }
+        return scan(files: allRolloutFiles(under: sessionsDir), now: now)
+    }
+
+    /// Existing `sessionsDir/yyyy/MM/dd` directories for the last
+    /// `lookbackDays` calendar days, newest-day-first. Uses the device's local
+    /// calendar/timezone, matching how Codex (running on the same machine)
+    /// buckets its own session folders.
+    private static func recentDayDirectories(under sessionsDir: URL, now: Date) -> [URL] {
+        let calendar = Calendar.current
+        var dirs: [URL] = []
+        for offset in 0..<lookbackDays {
+            guard let day = calendar.date(byAdding: .day, value: -offset, to: now) else { continue }
+            let url = sessionsDir.appendingPathComponent(dayPathFormatter.string(from: day))
+            var isDir: ObjCBool = false
+            if FileManager.default.fileExists(atPath: url.path, isDirectory: &isDir), isDir.boolValue {
+                dirs.append(url)
+            }
+        }
+        return dirs
+    }
+
+    private static let dayPathFormatter: DateFormatter = {
+        let f = DateFormatter()
+        f.dateFormat = "yyyy/MM/dd"
+        f.calendar = Calendar.current
+        f.timeZone = .current
+        return f
+    }()
+
+    /// Rollout files directly inside one `yyyy/MM/dd` leaf directory — Codex
+    /// never nests further than that, so a shallow listing suffices (no need
+    /// to stat every file in the tree, unlike the recursive fallback).
+    private static func rolloutFiles(in dayDir: URL) -> [RolloutFile] {
+        let resourceKeys: [URLResourceKey] = [.isRegularFileKey, .contentModificationDateKey]
+        guard let entries = try? FileManager.default.contentsOfDirectory(
+            at: dayDir,
+            includingPropertiesForKeys: resourceKeys,
+            options: [.skipsHiddenFiles]
+        ) else { return [] }
+
+        return entries.compactMap { file -> RolloutFile? in
+            guard file.pathExtension == "jsonl", file.lastPathComponent.hasPrefix("rollout-") else { return nil }
+            let values = try? file.resourceValues(forKeys: Set(resourceKeys))
+            guard values?.isRegularFile != false else { return nil }
+            return RolloutFile(url: file, modifiedAt: values?.contentModificationDate)
+        }
+    }
+
+    /// Full recursive walk of `sessionsDir` — only reached when it doesn't
+    /// follow the `yyyy/MM/dd` layout the fast path expects.
+    private static func allRolloutFiles(under sessionsDir: URL) -> [RolloutFile] {
         let fm = FileManager.default
         let resourceKeys: [URLResourceKey] = [.isRegularFileKey, .contentModificationDateKey]
         guard let enumerator = fm.enumerator(
             at: sessionsDir,
             includingPropertiesForKeys: resourceKeys,
             options: [.skipsHiddenFiles]
-        ) else { return nil }
+        ) else { return [] }
 
         var files: [RolloutFile] = []
         for case let file as URL in enumerator {
@@ -89,10 +159,17 @@ enum CodexRateLimitReader {
             guard values?.isRegularFile != false else { continue }
             files.append(.init(url: file, modifiedAt: values?.contentModificationDate))
         }
+        return files
+    }
 
+    /// Sort newest-first and scan until a confirmed latest snapshot is found.
+    /// Files are monotonic writers, so once the next candidate's mtime is no
+    /// newer than the best event timestamp seen so far, it cannot contain a
+    /// later append and the remaining files can be skipped safely.
+    private static func scan(files: [RolloutFile], now: Date) -> Snapshot? {
         // Missing mtimes are scanned first so the optimization can never hide
         // a valid snapshot merely because metadata lookup failed.
-        files.sort {
+        let sorted = files.sorted {
             switch ($0.modifiedAt, $1.modifiedAt) {
             case let (lhs?, rhs?):
                 if lhs == rhs { return $0.url.path > $1.url.path }
@@ -107,7 +184,7 @@ enum CodexRateLimitReader {
         }
 
         var latest: Snapshot?
-        for file in files {
+        for file in sorted {
             if let latest,
                let modifiedAt = file.modifiedAt,
                modifiedAt <= latest.recordedAt {

--- a/VibeUsage/Services/CodexUsageAPIReader.swift
+++ b/VibeUsage/Services/CodexUsageAPIReader.swift
@@ -1,0 +1,184 @@
+import Foundation
+
+/// Fetches Codex usage + rate-limit-reset credits from ChatGPT's backend using
+/// the user's *own* locally-stored OAuth token.
+///
+/// This is the one piece of the rate-limit feature that isn't a pure local-file
+/// read: the "reset credits" count (how many manual usage-window resets the
+/// account has banked) lives only server-side — no local file carries it. The
+/// same endpoint also returns live window utilization, which is fresher and
+/// more accurate than walking Codex's session JSONL (that walk can surface
+/// stale/expired windows), so we prefer it as the primary source and fall back
+/// to `CodexRateLimitReader` when the network/token isn't available.
+///
+/// Endpoint & shape are from Codex's own open-source backend client
+/// (`codex-rs/backend-client`): the official CLI/app-server hits the exact same
+/// `GET /backend-api/wham/usage`. We only ever GET — we never touch the
+/// `.../consume` POST, which would actually spend a reset credit.
+///
+/// Privacy: the access token is read from `~/.codex/auth.json`, used only to
+/// authenticate this request to `chatgpt.com`, and never logged, persisted, or
+/// forwarded to the Vibe Usage backend.
+enum CodexUsageAPIReader {
+
+    private static let usageURL = URL(string: "https://chatgpt.com/backend-api/wham/usage")!
+    private static let requestTimeout: TimeInterval = 10
+
+    /// Returns a fully-populated snapshot on success, or nil when the API can't
+    /// be used (no token, expired token → 401, offline, timeout, unexpected
+    /// shape). A nil return is the caller's cue to fall back to the local
+    /// session-file reader.
+    static func fetch(now: Date = Date()) async -> ProviderRateLimit? {
+        guard let auth = CodexAuth.load() else {
+            debugLog("[rate-limit] codex API: no auth.json / access token — skipping API path")
+            return nil
+        }
+
+        var request = URLRequest(url: usageURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = requestTimeout
+        request.setValue("Bearer \(auth.accessToken)", forHTTPHeaderField: "Authorization")
+        request.setValue("codex-cli", forHTTPHeaderField: "User-Agent")
+        request.setValue("application/json", forHTTPHeaderField: "Accept")
+        // Sent only when present; the server accepts the request with or without it.
+        if let accountId = auth.accountId {
+            request.setValue(accountId, forHTTPHeaderField: "ChatGPT-Account-Id")
+        }
+
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let http = response as? HTTPURLResponse else { return nil }
+            debugLog("[rate-limit] codex API /wham/usage -> HTTP \(http.statusCode)")
+            guard http.statusCode == 200 else {
+                // 401 = token expired (Codex refreshes auth.json on its own next
+                // run); anything else = transient. Either way, fall back locally.
+                return nil
+            }
+            let decoder = JSONDecoder()
+            // The payload is snake_case at every level; a global strategy keeps
+            // nested structs in sync (a hand-written top-level CodingKeys would
+            // silently leave nested fields nil — they're all Optional).
+            decoder.keyDecodingStrategy = .convertFromSnakeCase
+            guard let payload = try? decoder.decode(WhamUsageResponse.self, from: data) else {
+                debugLog("[rate-limit] codex API: response shape changed — falling back")
+                return nil
+            }
+            return payload.toSnapshot(now: now)
+        } catch {
+            debugLog("[rate-limit] codex API request failed: \(error.localizedDescription)")
+            return nil
+        }
+    }
+}
+
+// MARK: - auth.json
+
+/// The minimal slice of `~/.codex/auth.json` we need. Respects `CODEX_HOME`.
+private struct CodexAuth {
+    let accessToken: String
+    let accountId: String?
+
+    static func load() -> CodexAuth? {
+        let base: URL
+        if let home = ProcessInfo.processInfo.environment["CODEX_HOME"], !home.isEmpty {
+            base = URL(fileURLWithPath: (home as NSString).expandingTildeInPath)
+        } else {
+            base = FileManager.default.homeDirectoryForCurrentUser.appendingPathComponent(".codex")
+        }
+        let url = base.appendingPathComponent("auth.json")
+        guard let data = try? Data(contentsOf: url),
+              let obj = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+              let tokens = obj["tokens"] as? [String: Any],
+              let token = tokens["access_token"] as? String, !token.isEmpty
+        else { return nil }
+        return CodexAuth(accessToken: token, accountId: tokens["account_id"] as? String)
+    }
+}
+
+// MARK: - Response shape
+
+/// Mirrors the subset of `RateLimitStatusWithResetCredits` we consume
+/// (`codex-rs/backend-client/src/types.rs`). Every field is optional so a
+/// server-side rename degrades to a partial/failed parse rather than a crash.
+private struct WhamUsageResponse: Decodable {
+    let planType: String?
+    let rateLimit: RateLimitObj?
+    let rateLimitResetCredits: ResetCredits?
+
+    struct RateLimitObj: Decodable {
+        let primaryWindow: Window?
+        let secondaryWindow: Window?
+    }
+
+    struct Window: Decodable {
+        let usedPercent: Double?
+        let limitWindowSeconds: Double?
+        let resetAt: Double?
+        let resetAfterSeconds: Double?
+    }
+
+    struct ResetCredits: Decodable {
+        let availableCount: Int?
+    }
+
+    func toSnapshot(now: Date) -> ProviderRateLimit? {
+        // `primary`/`secondary` have no fixed meaning — classify each by its
+        // `limit_window_seconds` (300min → 5h, 10080min → 7d), mirroring the
+        // local reader. Whichever slot carries the 5h window becomes `fiveHour`.
+        var five: RateLimitWindow?
+        var seven: RateLimitWindow?
+        for slot in [rateLimit?.primaryWindow, rateLimit?.secondaryWindow] {
+            guard let parsed = classify(slot, now: now) else { continue }
+            switch parsed.minutes {
+            case 300:   five = parsed.window
+            case 10080: seven = parsed.window
+            default:    continue
+            }
+        }
+
+        // If neither window has live data, there's nothing to render — signal a
+        // miss so the caller can fall back to the local session-file reader
+        // (which might still have a recent snapshot).
+        guard five != nil || seven != nil else { return nil }
+
+        return ProviderRateLimit(
+            provider: .codex,
+            fiveHour: five,
+            sevenDay: seven,
+            planLabel: formatPlanLabel(planType),
+            resetCredits: rateLimitResetCredits?.availableCount,
+            status: .ok,
+            fetchedAt: now
+        )
+    }
+
+    /// Parse one API window into a `RateLimitWindow` plus its length in minutes
+    /// (so the caller can bucket it). Drops a window whose reset is already in
+    /// the past — same guard as the local reader against stale figures.
+    private func classify(_ w: Window?, now: Date) -> (window: RateLimitWindow, minutes: Int)? {
+        guard let w, let used = w.usedPercent, let seconds = w.limitWindowSeconds else { return nil }
+        let minutes = Int((seconds / 60).rounded())
+
+        var resetsAt: Date?
+        if let epoch = w.resetAt, epoch > 0 {
+            resetsAt = Date(timeIntervalSince1970: epoch)
+        } else if let after = w.resetAfterSeconds, after >= 0 {
+            resetsAt = now.addingTimeInterval(after)
+        }
+        if let resetsAt, resetsAt.timeIntervalSince(now) <= 0 { return nil }
+
+        return (
+            RateLimitWindow(
+                utilization: used,
+                resetsAt: resetsAt,
+                windowDuration: TimeInterval(minutes * 60)
+            ),
+            minutes
+        )
+    }
+
+    private func formatPlanLabel(_ raw: String?) -> String? {
+        guard let raw, !raw.isEmpty else { return nil }
+        return raw.prefix(1).uppercased() + raw.dropFirst()
+    }
+}

--- a/VibeUsage/Services/MenuBarController.swift
+++ b/VibeUsage/Services/MenuBarController.swift
@@ -59,6 +59,14 @@ final class MenuBarController: NSObject {
     private var globalEventMonitor: Any?
     private var localEventMonitor: Any?
     private var isAnimating = false
+    private var rateLimitPollTimer: Timer?
+
+    /// While the panel is open, poll for fresher quota numbers so a user
+    /// watching the card doesn't have to close/reopen to see it update.
+    /// Shorter than the coordinator's 60s per-provider cooldown so a tick
+    /// never misses the moment that cooldown lapses; the cooldown itself
+    /// (not this interval) is what actually paces the real reads.
+    private static let rateLimitPollInterval: TimeInterval = 20
 
     /// Both surfaces want the panel lowered to `.normal` while they're up, and
     /// they can overlap (e.g. an update session started from Settings). Each
@@ -263,15 +271,35 @@ final class MenuBarController: NSObject {
         panel.makeKeyAndOrderFront(nil)
         animateOpen(panel)
         installEventMonitors()
+        startRateLimitPolling()
     }
 
     private func closePanel() {
         guard let panel, panel.isVisible, !isAnimating else { return }
+        stopRateLimitPolling()
         animateClose(panel) { [weak self] in
             panel.orderOut(nil)
             ActivationCoordinator.shared.popupDidClose()
             self?.removeEventMonitors()
         }
+    }
+
+    /// Re-fires the same debounced refresh popover-open already uses — this
+    /// timer just decides *when* to ask, the coordinator's 60s cooldown still
+    /// decides whether that ask turns into an actual file read. Local-file
+    /// reads only, so this is free background work, not a new network poll.
+    private func startRateLimitPolling() {
+        stopRateLimitPolling()
+        rateLimitPollTimer = Timer.scheduledTimer(withTimeInterval: Self.rateLimitPollInterval, repeats: true) { [weak self] _ in
+            guard let self else { return }
+            Task { await self.appState.refreshCodexRateLimitIfNeeded() }
+            Task { await self.appState.refreshClaudeRateLimitIfNeeded() }
+        }
+    }
+
+    private func stopRateLimitPolling() {
+        rateLimitPollTimer?.invalidate()
+        rateLimitPollTimer = nil
     }
 
     private func ensurePanel() -> PopoverPanel {

--- a/VibeUsage/Services/RateLimitCoordinator.swift
+++ b/VibeUsage/Services/RateLimitCoordinator.swift
@@ -12,6 +12,13 @@ final class RateLimitCoordinator {
     private var lastCodexFetchAt: Date?
     private var lastClaudeFetchAt: Date?
 
+    /// Both reads are local-file scans that should complete in well under a
+    /// second; these are a safety net against a pathological filesystem (e.g.
+    /// a network-mounted home directory) hanging the UI in "loading" forever
+    /// rather than a tuned budget for the happy path.
+    private static let codexTimeout: TimeInterval = 6
+    private static let claudeTimeout: TimeInterval = 3
+
     init(appState: AppState) {
         self.appState = appState
     }
@@ -21,9 +28,21 @@ final class RateLimitCoordinator {
     /// debounced `refreshCodexIfNeeded` to avoid repeat work on rapid open/close.
     func refreshCodex() async {
         guard appState?.codexRateLimitEnabled == true else { return }
-        let codex = await Task.detached(priority: .userInitiated) {
-            CodexRateLimitReader.read()
-        }.value
+        markFetching(.codex, true)
+        let codex = await Self.withTimeout(Self.codexTimeout) {
+            // Prefer the live API (fresher windows + the only source of the
+            // reset-credit count). Fall back to the local session-file walk when
+            // the token/network isn't available so the card still works offline.
+            if let api = await CodexUsageAPIReader.fetch() {
+                return api
+            }
+            debugLog("[rate-limit] codex API unavailable — falling back to local session files")
+            return await Task.detached(priority: .userInitiated) {
+                CodexRateLimitReader.read()
+            }.value
+        } onTimeout: {
+            ProviderRateLimit(provider: .codex, status: .error("读取超时，请重试"), fetchedAt: Date())
+        }
         upsert(codex)
         lastCodexFetchAt = Date()
     }
@@ -43,9 +62,14 @@ final class RateLimitCoordinator {
     func refreshClaude() async {
         guard appState?.claudeRateLimitEnabled == true else { return }
         debugLog("[rate-limit] refreshClaude() entered")
-        let snapshot = await Task.detached(priority: .userInitiated) {
-            ClaudeRateLimitReader.read()
-        }.value
+        markFetching(.claudeCode, true)
+        let snapshot = await Self.withTimeout(Self.claudeTimeout) {
+            await Task.detached(priority: .userInitiated) {
+                ClaudeRateLimitReader.read()
+            }.value
+        } onTimeout: {
+            ProviderRateLimit(provider: .claudeCode, status: .error("读取超时，请重试"), fetchedAt: Date())
+        }
         debugLog("[rate-limit] refreshClaude() got snapshot status=\(snapshot.status)")
         upsert(snapshot)
         lastClaudeFetchAt = Date()
@@ -66,16 +90,34 @@ final class RateLimitCoordinator {
         await refreshClaude()
     }
 
-    /// Ensure both providers have at least a placeholder entry so the UI renders
-    /// the disabled / enable affordance for Claude on first launch.
+    /// Ensure both providers have at least a placeholder entry so the card
+    /// renders instantly on first launch — `.loading` rather than `.noData` /
+    /// `.disabled`, since a refresh is about to run and we don't want the
+    /// card to flash "no data" and then pop into existence a moment later.
     func seedPlaceholders() {
         if appState?.codexRateLimitEnabled == true,
            appState?.rateLimits.contains(where: { $0.provider == .codex }) != true {
-            upsert(ProviderRateLimit(provider: .codex, status: .noData, fetchedAt: nil))
+            upsert(ProviderRateLimit(provider: .codex, status: .loading, fetchedAt: nil, isFetching: true))
         }
         if appState?.claudeRateLimitEnabled == true,
            appState?.rateLimits.contains(where: { $0.provider == .claudeCode }) != true {
-            upsert(ProviderRateLimit(provider: .claudeCode, status: .disabled, fetchedAt: nil))
+            upsert(ProviderRateLimit(provider: .claudeCode, status: .loading, fetchedAt: nil, isFetching: true))
+        }
+    }
+
+    /// Mark a provider as "refresh in flight" without disturbing its existing
+    /// status/data — a background refresh (popover reopened, manual retry)
+    /// should keep showing the last-known numbers, just with a subtle
+    /// in-progress indicator, rather than reverting to a loading skeleton.
+    /// Only seeds a fresh `.loading` placeholder when no entry exists yet.
+    private func markFetching(_ provider: ProviderRateLimit.Provider, _ fetching: Bool) {
+        guard let appState else { return }
+        var current = appState.rateLimits
+        if let i = current.firstIndex(where: { $0.provider == provider }) {
+            current[i].isFetching = fetching
+            appState.rateLimits = current
+        } else if fetching {
+            upsert(ProviderRateLimit(provider: provider, status: .loading, isFetching: true))
         }
     }
 
@@ -88,5 +130,25 @@ final class RateLimitCoordinator {
             current.append(snapshot)
         }
         appState.rateLimits = current
+    }
+
+    /// Race `operation` against a `seconds` timer; whichever finishes first
+    /// wins and the loser is cancelled. Keeps a stalled local-file read from
+    /// leaving the UI stuck in "loading" indefinitely.
+    private static func withTimeout<T: Sendable>(
+        _ seconds: TimeInterval,
+        operation: @escaping @Sendable () async -> T,
+        onTimeout: @escaping @Sendable () -> T
+    ) async -> T {
+        await withTaskGroup(of: T.self) { group in
+            group.addTask { await operation() }
+            group.addTask {
+                try? await Task.sleep(for: .seconds(seconds))
+                return onTimeout()
+            }
+            let result = await group.next() ?? onTimeout()
+            group.cancelAll()
+            return result
+        }
     }
 }

--- a/VibeUsage/Views/RateLimitCardView.swift
+++ b/VibeUsage/Views/RateLimitCardView.swift
@@ -88,6 +88,7 @@ private struct ProviderCard: View {
             header
             content
         }
+        .animation(.easeInOut(duration: 0.2), value: snapshot.status)
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .padding(.horizontal, 12)
         .padding(.vertical, 11)
@@ -116,7 +117,34 @@ private struct ProviderCard: View {
             Text(snapshot.provider.displayName)
                 .font(.system(size: 13, weight: .semibold))
                 .foregroundStyle(.white)
+            // A background refresh (popover reopened, manual retry) keeps the
+            // last-known numbers on screen — this is the only signal that a
+            // read is in flight. Only shown once we have real data; the
+            // first-ever load uses the full `.loading` skeleton instead.
+            if snapshot.isFetching && snapshot.status == .ok {
+                ProgressView()
+                    .controlSize(.mini)
+                    .tint(Color(white: 0.5))
+                    .transition(.opacity)
+            }
             Spacer()
+            // Banked manual-reset credits (Codex). Only shown when the account
+            // actually has one or more — a subtle accent capsule marks it as a
+            // usable benefit rather than just another stat.
+            if let credits = snapshot.resetCredits, credits > 0 {
+                HStack(spacing: 3) {
+                    Image(systemName: "arrow.clockwise")
+                        .font(.system(size: 9, weight: .bold))
+                    Text("\(credits)")
+                        .font(.system(size: 10, weight: .semibold))
+                }
+                .foregroundStyle(Color(red: 0.38, green: 0.78, blue: 0.6))
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(Color(red: 0.38, green: 0.78, blue: 0.6).opacity(0.16))
+                .clipShape(Capsule())
+                .help("可用额度重置券：\(credits) 张（可手动重置一次用量窗口）")
+            }
             if let label = snapshot.planLabel {
                 Text(label)
                     .font(.system(size: 10, weight: .medium))
@@ -134,6 +162,7 @@ private struct ProviderCard: View {
     @ViewBuilder
     private var content: some View {
         switch snapshot.status {
+        case .loading:       loadingContent
         case .ok:           quotaRows
         case .disabled:
             if snapshot.provider == .claudeCode && appState.claudeRateLimitEnabled {
@@ -172,30 +201,16 @@ private struct ProviderCard: View {
         }
     }
 
-    /// Visible rows in display order. Paid Codex plans always reserve the 5h
-    /// slot — if utilization is unknown (no recent activity, so `parseWindow`
-    /// dropped the expired window) we render a placeholder rather than letting
-    /// the 7d row shift up and pose as 5h. Free Codex / Claude never get the
-    /// 5h placeholder because those plans don't carry that window at all.
+    /// Visible rows in display order. Codex retired its 5h window — only the
+    /// 7d rolling window remains — so we never render a 5h row for it. Claude
+    /// still reports both 5h and 7d.
     private var visibleRows: [RowItem] {
         var out: [RowItem] = []
-        if let w = snapshot.fiveHour {
+        if snapshot.provider != .codex, let w = snapshot.fiveHour {
             out.append(.live(label: "5h", window: w))
-        } else if expectsFiveHourWindow {
-            out.append(.placeholder(label: "5h", message: "近 5 小时无活动"))
         }
         if let w = snapshot.sevenDay { out.append(.live(label: "7d", window: w)) }
         return out
-    }
-
-    /// True only for paid Codex plans (Plus / Pro / Business), where Codex
-    /// emits both `primary` and `secondary` windows in every `token_count`
-    /// payload. Free-tier and Claude payloads don't carry a 5h window, so
-    /// reserving the slot would just confuse users on those plans.
-    private var expectsFiveHourWindow: Bool {
-        guard snapshot.provider == .codex,
-              let plan = snapshot.planLabel?.lowercased() else { return false }
-        return plan == "plus" || plan == "pro" || plan == "prolite" || plan == "business"
     }
 
     @ViewBuilder
@@ -234,6 +249,17 @@ private struct ProviderCard: View {
             }
         }
         .animation(.easeOut(duration: 0.12), value: hoveredLabel)
+    }
+
+    /// Shown while the first-ever read for this provider is in flight — we
+    /// don't yet know whether the plan has one row (free tier) or two
+    /// (5h + 7d), so two generic placeholder rows is the best guess that
+    /// keeps the card's footprint stable once real data lands.
+    private var loadingContent: some View {
+        VStack(alignment: .leading, spacing: rowSpacing) {
+            SkeletonQuotaRow().frame(height: rowHeight)
+            SkeletonQuotaRow().frame(height: rowHeight)
+        }
     }
 
     @ViewBuilder
@@ -450,6 +476,36 @@ private struct EmptyQuotaRow: View {
                 .lineLimit(1)
                 .truncationMode(.tail)
                 .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+}
+
+// MARK: - Skeleton quota row
+
+/// Loading placeholder for one quota row — same label / bar / percent
+/// proportions as `QuotaRow` so the card doesn't jump in height once real
+/// data replaces it. Pulses gently rather than a full shimmer sweep, to stay
+/// in keeping with the card's otherwise static, minimal chrome.
+private struct SkeletonQuotaRow: View {
+    @State private var pulse = false
+
+    var body: some View {
+        HStack(alignment: .center, spacing: 6) {
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(white: 0.16))
+                .frame(width: 20, height: 10)
+            RoundedRectangle(cornerRadius: 3)
+                .fill(Color(white: 0.16))
+                .frame(height: 6)
+            RoundedRectangle(cornerRadius: 2)
+                .fill(Color(white: 0.16))
+                .frame(width: 30, height: 10)
+        }
+        .opacity(pulse ? 0.75 : 0.35)
+        .onAppear {
+            withAnimation(.easeInOut(duration: 0.9).repeatForever(autoreverses: true)) {
+                pulse = true
+            }
         }
     }
 }


### PR DESCRIPTION
### 🆕 新增：Codex 实时用量 + 额度重置券
- Codex 配额改为读取官方 Codex CLI 同款端点 `GET /backend-api/wham/usage`（用用户本机 `~/.codex/auth.json` 里自己的 OAuth token）。
- 由此拿到本地会话文件**无法获取**的两项数据：
  - **额度重置券数量**（`rate_limit_reset_credits.available_count`）——即 Codex 发放的「手动重置一次用量窗口」的券，在卡片头部以强调色徽章 `↺ N` 展示。此数据仅存在于服务端。
  - **实时窗口用量**——比解析本地 session JSONL 更准，避免读到已过期的窗口数据。
- 本地会话文件读取保留为**兜底**：离线 / token 过期(401) / 未登录时自动回退，卡片仍可离线工作。

### 🆕 新增：Claude 订阅等级显示
- 从 `~/.claude.json` 的 `oauthAccount.organizationRateLimitTier` 读取并展示 **Pro / Max 5x / Max 20x**。
- 该文件是普通 0644 配置，**不走 Keychain、不弹系统授权框**；且比 Keychain 里的 `subscriptionType`（只有笼统的 `max`）更细，能区分 5x/20x。statusline payload 本身不含等级字段。

### ⚡ 优化：Codex 会话扫描性能
- 原实现每次刷新都递归遍历整个 `~/.codex/sessions` 历史（长期用户可达数百文件、数 GB），首次打开面板明显卡顿。
- 超过 7 天窗口的 `rate_limits` 事件必然已过期，故将扫描限界到最近几天的 `yyyy/MM/dd` 目录；非标准布局保留全量扫描兜底。

### ⚡ 优化：加载态 / 骨架屏 / 超时 / 自动轮询
- 首次读取显示骨架屏占位；后台刷新时保留旧数据，仅在卡片头显示小 spinner，不再整块闪烁。
- 读取加超时保护，避免异常文件系统 / 网络挂起 UI。
- 面板打开期间自动轮询，配额数字保持实时。

### 🔧 修正：移除 Codex 5h 窗口
- Codex 已取消 5h 重置窗口（只剩 7d），卡片不再渲染 5h 行及其占位。Claude 仍保留 5h + 7d。

### 🧰 测试基础设施：DEBUG 环境变量覆盖 API 地址
- debug 构建可用 `VIBE_USAGE_API_URL=...` 指向真实后端做端到端登录测试，未设置时回退本地 dev server；对 release 构建无影响。

## 🔒 隐私与安全
- Codex token 仅从本机 `~/.codex/auth.json` 读取，**只用于向 `chatgpt.com` 请求用户自己账户的数据**，绝不打印 / 持久化 / 上传到 Vibe Usage 后端。
- **绝不**调用会消耗券的 `/rate-limit-reset-credits/consume` POST，只做只读 GET。
- Claude 等级读取为纯本地文件，零 Keychain、零系统授权。

## ⚠️ 设计说明（请 maintainer 关注）
Codex 用量从「纯本地文件」改为「**API 优先 + 本地兜底**」，因此引入了对 `chatgpt.com` 的网络请求（此前 rate-limit 部分是纯本地）。这是为了获取本地文件无法提供的 reset 券数量与实时用量。token 失效 / 离线时会无缝回退本地会话文件，不影响可用性。端点与字段均来自 OpenAI 开源的 `codex-rs/backend-client`（官方 CLI 自身使用）。

## 破坏性变更
无。所有新增数据源缺失时都优雅降级为原有行为。